### PR TITLE
refactor(table): use enum-based column config

### DIFF
--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -1,25 +1,39 @@
 import React from 'react';
-import type { Rule } from './RuleTable';
+import type { Rule } from '../types/rule';
+import { RuleColumn } from './columnConfig';
 import './RuleRow.css';
 
 interface RuleRowProps {
   rule: Rule;
+  columns: RuleColumn[];
 }
 
-const RuleRow: React.FC<RuleRowProps> = ({ rule }) => {
-  return (
-    <tr>
-      <td>
+const renderCell = (column: RuleColumn, rule: Rule): React.ReactNode => {
+  switch (column) {
+    case RuleColumn.UrlPattern:
+      return (
         <p title={rule.urlPattern} className="truncated-url">
           {rule.urlPattern}
         </p>
-      </td>
-      <td>{rule.method}</td>
-      <td>{rule.enabled ? 'Yes' : 'No'}</td>
-      <td>{rule.date}</td>
-      <td>
-        <button type="button">Edit</button>
-      </td>
+      );
+    case RuleColumn.Method:
+      return rule.method;
+    case RuleColumn.Enabled:
+      return rule.enabled ? 'Yes' : 'No';
+    case RuleColumn.Date:
+      return rule.date;
+    case RuleColumn.Edit:
+    default:
+      return <button type="button">Edit</button>;
+  }
+};
+
+const RuleRow: React.FC<RuleRowProps> = ({ rule, columns }) => {
+  return (
+    <tr>
+      {columns.map((column) => (
+        <td key={column}>{renderCell(column, rule)}</td>
+      ))}
     </tr>
   );
 };

--- a/src/components/RuleTable.tsx
+++ b/src/components/RuleTable.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import './style.css';
 import RuleRow from './RuleRow';
-
-export interface Rule {
-  id: string;
-  urlPattern: string;
-  method: string;
-  enabled: boolean;
-  date: string;
-}
+import type { Rule } from '../types/rule';
+import { COLUMN_ORDER, COLUMN_LABELS, RuleColumn } from './columnConfig';
 
 interface RuleTableProps {
   rules: Rule[];
@@ -19,19 +13,21 @@ const RuleTable: React.FC<RuleTableProps> = ({ rules }) => {
     <table>
       <thead>
         <tr>
-          <th className="header">URL Pattern</th>
-          <th className="header">Method</th>
-          <th className="header">Enabled</th>
-          <th className="header">Date</th>
-          <th className="header">Edit</th>
+          {COLUMN_ORDER.map((column) => (
+            <th key={column} className="header">
+              {COLUMN_LABELS[column]}
+            </th>
+          ))}
         </tr>
       </thead>
       <tbody>
         {rules.length > 0 ? (
-          rules.map((rule) => <RuleRow key={rule.id} rule={rule} />)
+          rules.map((rule) => (
+            <RuleRow key={rule.id} rule={rule} columns={COLUMN_ORDER} />
+          ))
         ) : (
           <tr>
-            <td colSpan={5} style={{ textAlign: 'center' }}>
+            <td colSpan={COLUMN_ORDER.length} style={{ textAlign: 'center' }}>
               No rules available
             </td>
           </tr>

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import RuleRow from '../RuleRow';
-import type { Rule } from '../RuleTable';
+import type { Rule } from '../../types/rule';
+import { COLUMN_ORDER } from '../columnConfig';
 
 const rule: Rule = {
   id: '1',
@@ -16,12 +17,15 @@ describe('<RuleRow />', () => {
     render(
       <table>
         <tbody>
-          <RuleRow rule={rule} />
+          <RuleRow rule={rule} columns={COLUMN_ORDER} />
         </tbody>
       </table>
     );
 
     const row = screen.getByRole('row');
+    const cells = row.querySelectorAll('td');
+    expect(cells).toHaveLength(COLUMN_ORDER.length);
+
     expect(row).toHaveTextContent(rule.urlPattern);
     expect(row).toHaveTextContent(rule.method);
     expect(row).toHaveTextContent('Yes');

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-import RuleTable, { Rule } from '../RuleTable';
+import RuleTable from '../RuleTable';
+import type { Rule } from '../../types/rule';
+import { COLUMN_ORDER, COLUMN_LABELS } from '../columnConfig';
 import mockRules from '../../mocks/rules.json';
 
 describe('<RuleTable />', () => {
@@ -22,11 +24,11 @@ describe('<RuleTable />', () => {
 
   it('renders the correct table headers', () => {
     renderRuleTable();
-    expect(screen.getByText('URL Pattern')).toBeInTheDocument();
-    expect(screen.getByText('Method')).toBeInTheDocument();
-    expect(screen.getByText('Enabled')).toBeInTheDocument();
-    expect(screen.getByText('Date')).toBeInTheDocument();
-    expect(screen.getByText('Edit')).toBeInTheDocument();
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(COLUMN_ORDER.length);
+    COLUMN_ORDER.forEach((column) => {
+      expect(screen.getByText(COLUMN_LABELS[column])).toBeInTheDocument();
+    });
   });
 
   it('renders rows with request data passed in the props', () => {
@@ -43,6 +45,9 @@ describe('<RuleTable />', () => {
     mockRules.forEach((rule, index) => {
       // rows[index + 1] because the first row is the header
       const row = rows[index + 1];
+      const cells = row.querySelectorAll('td');
+      expect(cells).toHaveLength(COLUMN_ORDER.length);
+
       expect(row).toHaveTextContent(rule.urlPattern);
       expect(row).toHaveTextContent(rule.method);
       expect(row).toHaveTextContent(rule.enabled ? 'Yes' : 'No');
@@ -51,6 +56,17 @@ describe('<RuleTable />', () => {
       const editButton = row.querySelector('button');
       expect(editButton).toBeInTheDocument();
       expect(editButton).toHaveTextContent('Edit');
+    });
+  });
+
+  it('header and row column counts match', () => {
+    renderRuleTable(mockRules);
+    const headerCells = screen.getAllByRole('columnheader');
+    const dataRows = screen.getAllByRole('row').slice(1);
+
+    dataRows.forEach((row) => {
+      const cells = row.querySelectorAll('td');
+      expect(cells).toHaveLength(headerCells.length);
     });
   });
 });

--- a/src/components/columnConfig.ts
+++ b/src/components/columnConfig.ts
@@ -1,0 +1,23 @@
+export enum RuleColumn {
+  UrlPattern = 'urlPattern',
+  Method = 'method',
+  Enabled = 'enabled',
+  Date = 'date',
+  Edit = 'edit',
+}
+
+export const COLUMN_ORDER: RuleColumn[] = [
+  RuleColumn.UrlPattern,
+  RuleColumn.Method,
+  RuleColumn.Enabled,
+  RuleColumn.Date,
+  RuleColumn.Edit,
+];
+
+export const COLUMN_LABELS: Record<RuleColumn, string> = {
+  [RuleColumn.UrlPattern]: 'URL Pattern',
+  [RuleColumn.Method]: 'Method',
+  [RuleColumn.Enabled]: 'Enabled',
+  [RuleColumn.Date]: 'Date',
+  [RuleColumn.Edit]: 'Edit',
+};

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -1,0 +1,7 @@
+export interface Rule {
+  id: string;
+  urlPattern: string;
+  method: string;
+  enabled: boolean;
+  date: string;
+}


### PR DESCRIPTION
## Summary
- add `RuleColumn` enum with `COLUMN_ORDER` and `COLUMN_LABELS`
- rewrite `RuleTable` and `RuleRow` to use the enum
- update unit tests to match new structure
- remove old `ruleColumns` configuration

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check` *(fails: missing type definitions)*