### PR TITLE
feat(panel): add filter component with table search

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface FilterProps {
+  value: string;
+  onFilterChange: (value: string) => void;
+}
+
+const Filter: React.FC<FilterProps> = ({ value, onFilterChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onFilterChange(e.target.value);
+  };
+
+  const handleClear = () => {
+    onFilterChange('');
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Type out to filter list"
+        value={value}
+        onChange={handleChange}
+      />
+      <button type="button" onClick={handleClear}>
+        Clear
+      </button>
+    </div>
+  );
+};
+
+export default Filter;

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -1,11 +1,36 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from '../../pages/Panel/App'; // Adjust the path if necessary
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from '../../pages/Panel/App';
+import mockData from '../../mocks/rules.json';
 
 describe('<App />', () => {
   it('renders the app container', () => {
     render(<App />);
     const appContainer = screen.getByTestId('app-container');
     expect(appContainer).toBeInTheDocument();
+  });
+
+  it('filters rules based on url', () => {
+    render(<App />);
+    const input = screen.getByPlaceholderText('Type out to filter list');
+    fireEvent.change(input, { target: { value: 'static' } });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2); // header + 1 filtered row
+    expect(
+      screen.getByText('https://static.example.com/*')
+    ).toBeInTheDocument();
+  });
+
+  it('clears the filter and shows all rules', () => {
+    render(<App />);
+    const input = screen.getByPlaceholderText('Type out to filter list');
+    fireEvent.change(input, { target: { value: 'static' } });
+
+    const clearButton = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(clearButton);
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(mockData.length + 1);
   });
 });

--- a/src/components/__tests__/Filter.test.tsx
+++ b/src/components/__tests__/Filter.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Filter from '../Filter';
+
+describe('<Filter />', () => {
+  it('calls onFilterChange when typing in input', () => {
+    const handleChange = jest.fn();
+    render(<Filter value="" onFilterChange={handleChange} />);
+
+    const input = screen.getByPlaceholderText('Type out to filter list');
+    fireEvent.change(input, { target: { value: 'api' } });
+    expect(handleChange).toHaveBeenCalledWith('api');
+  });
+
+  it('calls onFilterChange with empty string when clear button clicked', () => {
+    const handleChange = jest.fn();
+    render(<Filter value="some" onFilterChange={handleChange} />);
+
+    const button = screen.getByRole('button', { name: /clear/i });
+    fireEvent.click(button);
+    expect(handleChange).toHaveBeenCalledWith('');
+  });
+});

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 
 import './app.css';
 import RuleTable from '../../components/RuleTable';
 import mockData from '../../mocks/rules.json';
+import Filter from '../../components/Filter';
 
 const App: React.FC = () => {
+  const [filter, setFilter] = useState('');
+
+  const filteredRules = useMemo(() => {
+    if (!filter) return mockData;
+    return mockData.filter((rule) =>
+      rule.urlPattern.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [filter]);
+
   return (
     <div className="container">
       <h1>Dev Tools Panel</h1>
+      <Filter value={filter} onFilterChange={setFilter} />
       <div data-testid="app-container">
-        <RuleTable rules={mockData} />
+        <RuleTable rules={filteredRules} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a simple `Filter` component
- hook new filter into Panel `App`
- test the filter component and new behavior in the App
- capitalize filter placeholder

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*