### PR TITLE
Add Jest coverage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,24 @@ cd utils/certs/
 choco install mkcert -y
 mkcert -install && mkcert localhost 127.0.0.1 ::1
 ```
-
 macbook
 
 ```
 cd utils/certs/
 brew install mkcert
 mkcert -install && mkcert localhost 127.0.0.1 ::1
+```
+
+## Testing
+
+Run the unit tests using:
+
+```bash
+npm test
+```
+
+Generate a coverage report with:
+
+```bash
+npm run test:coverage
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "ts-node --project tsconfig.scripts.json utils/build.ts",
     "start": "ts-node --project tsconfig.scripts.json utils/webserver.ts",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"


### PR DESCRIPTION
## Summary
- add `test:coverage` npm script to run tests with coverage
- document how to generate coverage in the README

## Testing
- `npm run test:coverage` *(fails: jest not found)*