### PR TITLE
Add coverage difference script

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,4 +35,17 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Generate coverage
+        run: npm run test:coverage
+
+      - name: Compare coverage
+        run: npm run coverage:report > coverage-report.txt
+
+      - name: Comment coverage diff
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ github.token }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-file: coverage-report.txt
      

--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ Generate a coverage report with:
 ```bash
 npm run test:coverage
 ```
+
+Compare coverage with the previous baseline and print the result using a TypeScript utility:
+
+```bash
+npm run coverage:report
+
+The pull request workflow runs this command and posts its output as a comment on the PR, highlighting any drop in coverage.
+```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "ts-node --project tsconfig.scripts.json utils/webserver.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "coverage:report": "ts-node --project tsconfig.scripts.json utils/coverage-report.ts",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:silent": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",

--- a/utils/coverage-report.ts
+++ b/utils/coverage-report.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+function loadSummary(file: string): any | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const coveragePath = path.join(__dirname, '../coverage/coverage-summary.json');
+const baselinePath = path.join(__dirname, '../coverage-baseline.json');
+
+const current = loadSummary(coveragePath);
+if (!current) {
+  console.error(`No coverage summary found at ${coveragePath}`);
+  process.exit(1);
+}
+
+const baseline = loadSummary(baselinePath);
+if (!baseline) {
+  fs.writeFileSync(baselinePath, JSON.stringify(current, null, 2));
+  console.log(`Baseline coverage stored at ${baselinePath}`);
+  process.exit(0);
+}
+
+const metrics = Object.keys(current.total);
+let drop = false;
+
+let report = 'Coverage changes:\n';
+metrics.forEach((metric) => {
+  const basePct = baseline.total[metric].pct;
+  const currPct = current.total[metric].pct;
+  const diff = currPct - basePct;
+  const sign = diff >= 0 ? '+' : '';
+  report += `${metric}: ${basePct}% -> ${currPct}% (${sign}${diff.toFixed(2)}%)\n`;
+  if (diff < 0) drop = true;
+});
+
+if (drop) {
+  report += 'Coverage dropped in this change.\n';
+}
+
+console.log(report);


### PR DESCRIPTION
## Summary
- add a script that compares current test coverage with a baseline
- document how to run the new coverage comparison
- expose `coverage:report` npm script
- comment coverage difference on pull requests

## Testing
- `npm test` *(fails: jest not found)*