### PR TITLE
Add coverage difference script

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,6 +33,27 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Coverage
+        run: npm run test:coverage
+
+      - name: Compare coverage
+        run: npm run coverage:report > coverage-report.txt
+
+      - name: Comment coverage
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('coverage-report.txt', 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: report
+            });
+
       - name: Build
         run: npm run build
      

--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ Generate a coverage report with:
 ```bash
 npm run test:coverage
 ```
+
+Compare coverage with the previous baseline and print the result (runs a TypeScript script via `ts-node`):
+
+```bash
+npm run coverage:report
+```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "ts-node --project tsconfig.scripts.json utils/webserver.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "coverage:report": "ts-node --project tsconfig.scripts.json utils/coverage-report.ts",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:silent": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",

--- a/utils/coverage-report.ts
+++ b/utils/coverage-report.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env ts-node
+import fs from 'fs';
+import path from 'path';
+
+interface CoverageMetrics {
+  pct: number;
+}
+interface CoverageSummary {
+  total: Record<string, CoverageMetrics>;
+}
+
+function loadSummary(file: string): CoverageSummary | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as CoverageSummary;
+  } catch {
+    return null;
+  }
+}
+
+const coveragePath = path.join(__dirname, '../coverage/coverage-summary.json');
+const baselinePath = path.join(__dirname, '../coverage-baseline.json');
+
+const current = loadSummary(coveragePath);
+if (!current) {
+  console.log(`No coverage summary found at ${coveragePath}`);
+  process.exit(0);
+}
+
+const baseline = loadSummary(baselinePath);
+if (!baseline) {
+  fs.writeFileSync(baselinePath, JSON.stringify(current, null, 2));
+  console.log(`Baseline coverage stored at ${baselinePath}`);
+  process.exit(0);
+}
+
+const metrics = Object.keys(current.total);
+let drop = false;
+
+console.log('Coverage changes:');
+for (const metric of metrics) {
+  const basePct = baseline.total[metric].pct;
+  const currPct = current.total[metric].pct;
+  const diff = currPct - basePct;
+  const sign = diff >= 0 ? '+' : '';
+  console.log(`${metric}: ${basePct}% -> ${currPct}% (${sign}${diff.toFixed(2)}%)`);
+  if (diff < 0) drop = true;
+}
+
+if (drop) {
+  console.log('Coverage dropped in this change.');
+}

--- a/utils/coverage-report.ts
+++ b/utils/coverage-report.ts
@@ -42,7 +42,9 @@ for (const metric of metrics) {
   const currPct = current.total[metric].pct;
   const diff = currPct - basePct;
   const sign = diff >= 0 ? '+' : '';
-  console.log(`${metric}: ${basePct}% -> ${currPct}% (${sign}${diff.toFixed(2)}%)`);
+  console.log(
+    `${metric}: ${basePct}% -> ${currPct}% (${sign}${diff.toFixed(2)}%)`
+  );
   if (diff < 0) drop = true;
 }
 


### PR DESCRIPTION
## Summary
- add a script that compares current test coverage with a baseline
- document how to run the new coverage comparison
- expose `coverage:report` npm script
- update GitHub workflow to post coverage difference on PRs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:coverage` *(fails: jest not found)*
- `npm run coverage:report` *(fails: ts-node not found)*
