### PR TITLE
Add delete action to rule table

### DIFF
--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -24,7 +24,12 @@ const renderCell = (column: RuleColumn, rule: Rule): React.ReactNode => {
       return rule.date;
     case RuleColumn.Edit:
     default:
-      return <button type="button">Edit</button>;
+      return (
+        <>
+          <button type="button">Edit</button>
+          <button type="button">Delete</button>
+        </>
+      );
   }
 };
 

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -33,6 +33,8 @@ describe('<RuleRow />', () => {
     expect(row).toHaveTextContent(rule.date);
 
     const editButton = screen.getByRole('button', { name: 'Edit' });
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
     expect(editButton).toBeInTheDocument();
+    expect(deleteButton).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -53,9 +53,10 @@ describe('<RuleTable />', () => {
       expect(row).toHaveTextContent(rule.enabled ? 'Yes' : 'No');
       expect(row).toHaveTextContent(rule.date);
 
-      const editButton = row.querySelector('button');
-      expect(editButton).toBeInTheDocument();
-      expect(editButton).toHaveTextContent('Edit');
+      const buttons = row.querySelectorAll('button');
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0]).toHaveTextContent('Edit');
+      expect(buttons[1]).toHaveTextContent('Delete');
     });
   });
 

--- a/src/components/columnConfig.ts
+++ b/src/components/columnConfig.ts
@@ -19,5 +19,5 @@ export const COLUMN_LABELS: Record<RuleColumn, string> = {
   [RuleColumn.Method]: 'Method',
   [RuleColumn.Enabled]: 'Enabled',
   [RuleColumn.Date]: 'Date',
-  [RuleColumn.Edit]: 'Edit',
+  [RuleColumn.Edit]: 'Actions',
 };


### PR DESCRIPTION
## Summary
- relabel Edit column header to Actions
- show Delete button in the actions column
- test for new delete button across table components

## Testing
- `npm test` *(fails: jest not found)*