### PR TITLE
Fix commitlint link

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,4 +1,4 @@
 {
   "extends": ["@commitlint/config-conventional"],
-  "helpUrl": "https://github.com/alejandrolechuga/request-interceptor/wiki#git-convetions"
+  "helpUrl": "https://github.com/alejandrolechuga/request-interceptor/wiki#git-conventions"
 }

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ npm run test:coverage
 ## Commit message guidelines
 
 Commits are checked with Commitlint and must follow the
-[Conventional Commits](https://github.com/alejandrolechuga/request-interceptor/wiki#git-convetions)
+[Conventional Commits](https://github.com/alejandrolechuga/request-interceptor/wiki#git-conventions)
 standard.


### PR DESCRIPTION
## Summary
- fix commit guidelines link in README
- update commitlint help URL

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint:commits` *(fails: commitlint not found)*