### PR TITLE
Add husky pre-commit hooks

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky:debug $1"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "$hook_name hook started"
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "using ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+  export husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+  debug "$hook_name hook finished: $exitCode"
+  exit $exitCode
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run prettier
+npm run lint
+npm run type-check

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:silent": "eslint . --ext .js,.jsx,.ts,.tsx --quiet",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "lint:commits": "commitlint --from=HEAD~1"
+    "lint:commits": "commitlint --from=HEAD~1",
+    "prepare": "husky install"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -95,7 +96,7 @@
     "webpack-dev-server": "^4.11.1",
     "zip-webpack-plugin": "^4.0.1",
     "@commitlint/cli": "^17.7.0",
-    "@commitlint/config-conventional": "^17.7.0"
+    "@commitlint/config-conventional": "^17.7.0",
+    "husky": "^9.0.0"
   }
 }
-


### PR DESCRIPTION
## Summary
- run husky on pre-commit and commit-msg
- check eslint, type check, and commit messages
- run prettier before linting
- install husky via npm prepare script

## Testing
- `npm run lint:silent` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.