### PR TITLE
Add redux-backed rule table

### DIFF
--- a/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
+++ b/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
@@ -1,0 +1,86 @@
+import reducer, {
+  addRule,
+  removeRule,
+  updateRule,
+  clearRules,
+  setRules,
+} from '../rulesetSlice';
+import type { Rule } from '../../../types/rule';
+
+describe('rulesetSlice', () => {
+  const initialState: Rule[] = [
+    {
+      id: '1',
+      urlPattern: 'https://api.example.com/*',
+      method: 'GET',
+      enabled: true,
+      date: '2024-01-01',
+      response: null,
+    },
+    {
+      id: '2',
+      urlPattern: 'https://static.example.com/*',
+      method: 'POST',
+      enabled: false,
+      date: '2024-02-01',
+      response: null,
+    },
+  ];
+
+  it('should add a rule', () => {
+    const newRule: Rule = {
+      id: '3',
+      urlPattern: 'https://new.example.com/*',
+      method: 'PUT',
+      enabled: true,
+      date: '2024-03-01',
+      response: null,
+    };
+    const state = reducer(initialState, addRule(newRule));
+    expect(state).toHaveLength(3);
+    expect(state[2]).toEqual(newRule);
+  });
+
+  it('should remove a rule by id', () => {
+    const state = reducer(initialState, removeRule('1'));
+    expect(state).toHaveLength(1);
+    expect(state.find((r) => r.id === '1')).toBeUndefined();
+  });
+
+  it('should update a rule by id', () => {
+    const state = reducer(
+      initialState,
+      updateRule({ id: '1', changes: { urlPattern: 'https://changed.com' } })
+    );
+    expect(state[0].urlPattern).toBe('https://changed.com');
+  });
+
+  it('should toggle the enabled state of a rule', () => {
+    const state = reducer(
+      initialState,
+      updateRule({ id: '2', changes: { enabled: true } })
+    );
+    const updated = state.find((r) => r.id === '2');
+    expect(updated?.enabled).toBe(true);
+  });
+
+  it('should clear all rules', () => {
+    const state = reducer(initialState, clearRules());
+    expect(state).toEqual([]);
+  });
+
+  it('should replace all rules with setRules', () => {
+    const replacement: Rule[] = [
+      {
+        id: '9',
+        urlPattern: 'https://replace.example.com/*',
+        method: 'GET',
+        enabled: false,
+        date: '2024-04-01',
+        response: null,
+      },
+    ];
+    const state = reducer(initialState, setRules(replacement));
+    expect(state).toEqual(replacement);
+  });
+});

--- a/src/Panel/ruleset/rulesetSlice.ts
+++ b/src/Panel/ruleset/rulesetSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { Rule } from '../../types/rule';
+
+type RuleUpdate = Partial<Pick<Rule, 'urlPattern' | 'method' | 'enabled'>>;
+
+const initialState: Rule[] = [];
+
+const rulesetSlice = createSlice({
+  name: 'ruleset',
+  initialState,
+  reducers: {
+    addRule(state, action: PayloadAction<Rule>) {
+      state.push(action.payload);
+    },
+    removeRule(state, action: PayloadAction<string>) {
+      return state.filter((rule) => rule.id !== action.payload);
+    },
+    updateRule(
+      state,
+      action: PayloadAction<{ id: string; changes: RuleUpdate }>
+    ) {
+      const rule = state.find((r) => r.id === action.payload.id);
+      if (rule) {
+        Object.assign(rule, action.payload.changes);
+      }
+    },
+    clearRules() {
+      return [] as Rule[];
+    },
+    setRules(_state, action: PayloadAction<Rule[]>) {
+      return action.payload;
+    },
+  },
+});
+
+export const { addRule, removeRule, updateRule, clearRules, setRules } =
+  rulesetSlice.actions;
+
+export default rulesetSlice.reducer;

--- a/src/components/RuleTable.tsx
+++ b/src/components/RuleTable.tsx
@@ -1,14 +1,22 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import './style.css';
 import RuleRow from './RuleRow';
-import type { Rule } from '../types/rule';
+import { useAppSelector } from '../store';
 import { COLUMN_ORDER, COLUMN_LABELS, RuleColumn } from './columnConfig';
 
 interface RuleTableProps {
-  rules: Rule[];
+  filter?: string;
 }
 
-const RuleTable: React.FC<RuleTableProps> = ({ rules }) => {
+const RuleTable: React.FC<RuleTableProps> = ({ filter = '' }) => {
+  const rules = useAppSelector((state) => state.ruleset);
+  const filteredRules = useMemo(() => {
+    if (!filter) return rules;
+    return rules.filter((rule) =>
+      rule.urlPattern.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [filter, rules]);
+
   return (
     <table>
       <thead>
@@ -21,8 +29,8 @@ const RuleTable: React.FC<RuleTableProps> = ({ rules }) => {
         </tr>
       </thead>
       <tbody>
-        {rules.length > 0 ? (
-          rules.map((rule) => (
+        {filteredRules.length > 0 ? (
+          filteredRules.map((rule) => (
             <RuleRow key={rule.id} rule={rule} columns={COLUMN_ORDER} />
           ))
         ) : (

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -2,15 +2,26 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
-
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
 import RuleTable from '../RuleTable';
 import type { Rule } from '../../types/rule';
 import { COLUMN_ORDER, COLUMN_LABELS } from '../columnConfig';
+import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
+import settingsReducer from '../../store/settingsSlice';
 import mockRules from '../../mocks/rules.json';
 
 describe('<RuleTable />', () => {
   const renderRuleTable = (rules: Rule[] = []) => {
-    render(<RuleTable rules={rules} />);
+    const store = configureStore({
+      reducer: { settings: settingsReducer, ruleset: rulesetReducer },
+      preloadedState: { settings: { enableRuleset: false }, ruleset: rules },
+    });
+    render(
+      <Provider store={store}>
+        <RuleTable />
+      </Provider>
+    );
   };
 
   beforeEach(() => {
@@ -31,7 +42,7 @@ describe('<RuleTable />', () => {
     });
   });
 
-  it('renders rows with request data passed in the props', () => {
+  it('renders rows from the store', () => {
     // Mock requests data
     renderRuleTable(mockRules);
 

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -22,7 +22,6 @@ const App: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-
   return (
     <div className="container">
       <h1>Dev Tools Panel</h1>

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setEnableRuleset } from '../../store/settingsSlice';
+import { addRule } from '../../Panel/ruleset/rulesetSlice';
 
 import './app.css';
 import RuleTable from '../../components/RuleTable';
@@ -11,13 +12,16 @@ const App: React.FC = () => {
   const [filter, setFilter] = useState('');
   const dispatch = useAppDispatch();
   const enableRuleset = useAppSelector((state) => state.settings.enableRuleset);
+  const rules = useAppSelector((state) => state.ruleset);
 
-  const filteredRules = useMemo(() => {
-    if (!filter) return mockData;
-    return mockData.filter((rule) =>
-      rule.urlPattern.toLowerCase().includes(filter.toLowerCase())
-    );
-  }, [filter]);
+  // Temporary: preload mock rules into the store once
+  useEffect(() => {
+    if (rules.length === 0) {
+      mockData.forEach((rule) => dispatch(addRule(rule)));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
 
   return (
     <div className="container">
@@ -32,7 +36,7 @@ const App: React.FC = () => {
       </label>
       <Filter value={filter} onFilterChange={setFilter} />
       <div data-testid="app-container">
-        <RuleTable rules={filteredRules} />
+        <RuleTable filter={filter} />
       </div>
     </div>
   );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import settingsReducer from './settingsSlice';
+import rulesetReducer from '../Panel/ruleset/rulesetSlice';
 
 export const store = configureStore({
   reducer: {
     settings: settingsReducer,
+    ruleset: rulesetReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- preload mock rules into redux store on app start
- render rules from store in `RuleTable`
- update table tests to use a configured store

## Testing
- `npm run lint:silent` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: jest not found)*