### PR TITLE
feat(ruleset): generate id for new rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react-dom": "^18.2.0",
         "react-redux": "*",
         "tailwind-merge": "*",
-        "tw-animate-css": "*"
+        "tw-animate-css": "*",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.27.1",
@@ -40,6 +41,7 @@
         "@types/react-dom": "^18.0.10",
         "@types/terser-webpack-plugin": "^5.2.0",
         "@types/testing-library__react": "^10.2.0",
+        "@types/uuid": "^10.0.0",
         "@types/webpack": "^5.28.5",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^29.7.0",
@@ -4294,6 +4296,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/webpack": {
@@ -15550,6 +15559,16 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -16903,10 +16922,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -20669,6 +20692,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
+    },
+    "@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "@types/webpack": {
       "version": "5.28.5",
@@ -28966,6 +28995,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -29949,10 +29986,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,15 +20,16 @@
     "lint:commits": "commitlint --from=HEAD~1"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "@reduxjs/toolkit": "*",
-    "react-redux": "*",
     "class-variance-authority": "*",
     "clsx": "*",
     "lucide-react": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "*",
     "tailwind-merge": "*",
-    "tw-animate-css": "*"
+    "tw-animate-css": "*",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.27.1",
@@ -36,6 +37,8 @@
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.27.1",
+    "@commitlint/cli": "^17.7.0",
+    "@commitlint/config-conventional": "^17.7.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -49,6 +52,7 @@
     "@types/react-dom": "^18.0.10",
     "@types/terser-webpack-plugin": "^5.2.0",
     "@types/testing-library__react": "^10.2.0",
+    "@types/uuid": "^10.0.0",
     "@types/webpack": "^5.28.5",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^29.7.0",
@@ -93,9 +97,6 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1",
-    "zip-webpack-plugin": "^4.0.1",
-    "@commitlint/cli": "^17.7.0",
-    "@commitlint/config-conventional": "^17.7.0"
+    "zip-webpack-plugin": "^4.0.1"
   }
 }
-

--- a/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
+++ b/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
@@ -28,8 +28,7 @@ describe('rulesetSlice', () => {
   ];
 
   it('should add a rule', () => {
-    const newRule: Rule = {
-      id: '3',
+    const newRule = {
       urlPattern: 'https://new.example.com/*',
       method: 'PUT',
       enabled: true,
@@ -38,7 +37,8 @@ describe('rulesetSlice', () => {
     };
     const state = reducer(initialState, addRule(newRule));
     expect(state).toHaveLength(3);
-    expect(state[2]).toEqual(newRule);
+    expect(state[2]).toMatchObject(newRule);
+    expect(state[2].id).toBeDefined();
   });
 
   it('should remove a rule by id', () => {

--- a/src/Panel/ruleset/rulesetSlice.ts
+++ b/src/Panel/ruleset/rulesetSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { v4 as uuidv4 } from 'uuid';
 import type { Rule } from '../../types/rule';
 
 type RuleUpdate = Partial<Pick<Rule, 'urlPattern' | 'method' | 'enabled'>>;
@@ -9,8 +10,13 @@ const rulesetSlice = createSlice({
   name: 'ruleset',
   initialState,
   reducers: {
-    addRule(state, action: PayloadAction<Rule>) {
-      state.push(action.payload);
+    addRule: {
+      reducer(state, action: PayloadAction<Rule>) {
+        state.push(action.payload);
+      },
+      prepare(rule: Omit<Rule, 'id'>) {
+        return { payload: { ...rule, id: uuidv4() } };
+      },
     },
     removeRule(state, action: PayloadAction<string>) {
       return state.filter((rule) => rule.id !== action.payload);

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
   // Temporary: preload mock rules into the store once
   useEffect(() => {
     if (rules.length === 0) {
-      mockData.forEach((rule) => dispatch(addRule(rule)));
+      mockData.forEach(({ id: _ignored, ...data }) => dispatch(addRule(data)));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## Summary
- ensure each rule gets a unique id when dispatched
- preload mock rules without their provided ids
- update tests for new rule creation
- depend on `uuid` for id generation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*