### PR TITLE
feat(settings): broadcast changes to intercept script

### DIFF
--- a/src/pages/Content/Intercept/setup.ts
+++ b/src/pages/Content/Intercept/setup.ts
@@ -3,6 +3,7 @@ import { RequestHandler } from './RequestHandler';
 import { RequestHandlerActions } from './RequestHandlerActions';
 import { interceptFetch } from './intercept';
 import { postMessage } from './contentScriptMessage';
+import { RuntimeMessage } from '../../../types/messages';
 
 export const setup = () => {
   const requestHandler = new RequestHandler();
@@ -16,6 +17,11 @@ export const setup = () => {
     }
   );
   interceptFetch(requestHandler);
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.action === RuntimeMessage.SETTINGS_UPDATE) {
+      console.log('Received settings update', message.settings);
+    }
+  });
   postMessage({
     action: InjectedEmittedEvents.INJECTED_READY,
     message: 'Injected page is ready',

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setEnableRuleset } from '../../store/settingsSlice';
 import { addRule } from '../../Panel/ruleset/rulesetSlice';
+import { RuntimeMessage } from '../../types/messages';
 
 import './app.css';
 import RuleTable from '../../components/RuleTable';
@@ -13,6 +14,13 @@ const App: React.FC = () => {
   const dispatch = useAppDispatch();
   const enableRuleset = useAppSelector((state) => state.settings.enableRuleset);
   const rules = useAppSelector((state) => state.ruleset);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage({
+      action: RuntimeMessage.SETTINGS_UPDATE,
+      settings: { enableRuleset },
+    });
+  }, [enableRuleset]);
 
   // Temporary: preload mock rules into the store once
   useEffect(() => {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,10 @@
+export enum RuntimeMessage {
+  SETTINGS_UPDATE = 'SETTINGS_UPDATE',
+}
+
+export interface SettingsUpdateMessage {
+  action: RuntimeMessage.SETTINGS_UPDATE;
+  settings: {
+    enableRuleset: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- broadcast changes from panel settings over `chrome.runtime` messaging
- listen for settings updates in the intercept script
- define runtime message types

## Testing
- `npm test` *(fails: jest not found)*