### PR TITLE
feat(panel): add add/edit rule views

### DIFF
--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import { useAppDispatch, useAppSelector } from '../store';
+import { addRule, updateRule } from '../Panel/ruleset/rulesetSlice';
+
+interface RuleFormProps {
+  mode: 'add' | 'edit';
+  ruleId?: string;
+  onBack: () => void;
+}
+
+const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
+  const dispatch = useAppDispatch();
+  const existing = useAppSelector((state) =>
+    state.ruleset.find((r) => r.id === ruleId)
+  );
+
+  const [urlPattern, setUrlPattern] = useState('');
+  const [method, setMethod] = useState('GET');
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    if (mode === 'edit' && existing) {
+      setUrlPattern(existing.urlPattern);
+      setMethod(existing.method);
+      setEnabled(existing.enabled);
+    }
+  }, [existing, mode]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (mode === 'add') {
+      dispatch(
+        addRule({
+          urlPattern,
+          method,
+          enabled,
+          date: new Date().toISOString().split('T')[0],
+          response: null,
+        })
+      );
+    } else if (mode === 'edit' && ruleId) {
+      dispatch(updateRule({ id: ruleId, changes: { urlPattern, method, enabled } }));
+    }
+    onBack();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <h2 className="text-xl font-bold">
+        {mode === 'edit' ? 'Edit Rule' : 'Add Rule'}
+      </h2>
+      <div className="flex flex-col gap-2">
+        <label className="flex flex-col">
+          <span>URL Pattern</span>
+          <input
+            type="text"
+            value={urlPattern}
+            onChange={(e) => setUrlPattern(e.target.value)}
+            className="rounded border border-gray-300 px-2 py-1 text-black"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span>Method</span>
+          <input
+            type="text"
+            value={method}
+            onChange={(e) => setMethod(e.target.value)}
+            className="rounded border border-gray-300 px-2 py-1 text-black"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+      </div>
+      <div className="space-x-2">
+        <button type="submit" className="rounded bg-blue-600 px-2 py-1">
+          Save
+        </button>
+        <button type="button" onClick={onBack} className="rounded bg-gray-600 px-2 py-1">
+          Back
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default RuleForm;

--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -39,7 +39,9 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
         })
       );
     } else if (mode === 'edit' && ruleId) {
-      dispatch(updateRule({ id: ruleId, changes: { urlPattern, method, enabled } }));
+      dispatch(
+        updateRule({ id: ruleId, changes: { urlPattern, method, enabled } })
+      );
     }
     onBack();
   };
@@ -81,7 +83,11 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
         <button type="submit" className="rounded bg-blue-600 px-2 py-1">
           Save
         </button>
-        <button type="button" onClick={onBack} className="rounded bg-gray-600 px-2 py-1">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded bg-gray-600 px-2 py-1"
+        >
           Back
         </button>
       </div>

--- a/src/components/RuleList.tsx
+++ b/src/components/RuleList.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import Filter from './Filter';
+import RuleTable from './RuleTable';
+
+interface RuleListProps {
+  onEdit: (id: string) => void;
+  onAdd: () => void;
+}
+
+const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
+  const [filter, setFilter] = useState('');
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between">
+        <Filter value={filter} onFilterChange={setFilter} />
+        <button
+          type="button"
+          onClick={onAdd}
+          className="rounded bg-green-600 px-2 py-1"
+        >
+          Add Rule
+        </button>
+      </div>
+      <RuleTable filter={filter} onEdit={onEdit} />
+    </div>
+  );
+};
+
+export default RuleList;

--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -7,11 +7,13 @@ import { removeRule } from '../Panel/ruleset/rulesetSlice';
 interface RuleRowProps {
   rule: Rule;
   columns: RuleColumn[];
+  onEdit: (id: string) => void;
 }
 
-const RuleRow: React.FC<RuleRowProps> = ({ rule, columns }) => {
+const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
   const dispatch = useAppDispatch();
   const handleDelete = () => dispatch(removeRule(rule.id));
+  const handleEdit = () => onEdit(rule.id);
 
   const renderCell = (column: RuleColumn): React.ReactNode => {
     switch (column) {
@@ -33,6 +35,7 @@ const RuleRow: React.FC<RuleRowProps> = ({ rule, columns }) => {
           <>
             <button
               type="button"
+              onClick={handleEdit}
               className="mr-2 text-blue-600 hover:underline"
             >
               Edit

--- a/src/components/RuleTable.tsx
+++ b/src/components/RuleTable.tsx
@@ -5,9 +5,10 @@ import { COLUMN_ORDER, COLUMN_LABELS, RuleColumn } from './columnConfig';
 
 interface RuleTableProps {
   filter?: string;
+  onEdit: (id: string) => void;
 }
 
-const RuleTable: React.FC<RuleTableProps> = ({ filter = '' }) => {
+const RuleTable: React.FC<RuleTableProps> = ({ filter = '', onEdit }) => {
   const rules = useAppSelector((state) => state.ruleset);
   const filteredRules = useMemo(() => {
     if (!filter) return rules;
@@ -33,7 +34,12 @@ const RuleTable: React.FC<RuleTableProps> = ({ filter = '' }) => {
       <tbody>
         {filteredRules.length > 0 ? (
           filteredRules.map((rule) => (
-            <RuleRow key={rule.id} rule={rule} columns={COLUMN_ORDER} />
+            <RuleRow
+              key={rule.id}
+              rule={rule}
+              columns={COLUMN_ORDER}
+              onEdit={onEdit}
+            />
           ))
         ) : (
           <tr>

--- a/src/components/__tests__/RuleForm.test.tsx
+++ b/src/components/__tests__/RuleForm.test.tsx
@@ -5,11 +5,15 @@ import { configureStore } from '@reduxjs/toolkit';
 import RuleForm from '../RuleForm';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
+import { Rule } from '../../../src/types/rule';
 
-const renderForm = (mode: 'add' | 'edit', preloadedRules = []) => {
+const renderForm = (mode: 'add' | 'edit', preloadedRules: Rule[] = []) => {
   const store = configureStore({
     reducer: { settings: settingsReducer, ruleset: rulesetReducer },
-    preloadedState: { settings: { enableRuleset: false }, ruleset: preloadedRules },
+    preloadedState: {
+      settings: { enableRuleset: false },
+      ruleset: preloadedRules,
+    },
   });
 
   const onBack = jest.fn();

--- a/src/components/__tests__/RuleForm.test.tsx
+++ b/src/components/__tests__/RuleForm.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import RuleForm from '../RuleForm';
+import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
+import settingsReducer from '../../store/settingsSlice';
+
+const renderForm = (mode: 'add' | 'edit', preloadedRules = []) => {
+  const store = configureStore({
+    reducer: { settings: settingsReducer, ruleset: rulesetReducer },
+    preloadedState: { settings: { enableRuleset: false }, ruleset: preloadedRules },
+  });
+
+  const onBack = jest.fn();
+
+  render(
+    <Provider store={store}>
+      <RuleForm mode={mode} ruleId={preloadedRules[0]?.id} onBack={onBack} />
+    </Provider>
+  );
+
+  return { store, onBack };
+};
+
+describe('<RuleForm />', () => {
+  it('adds a rule when submitted in add mode', () => {
+    const { store } = renderForm('add');
+
+    fireEvent.change(screen.getByLabelText(/url pattern/i), {
+      target: { value: 'https://example.com/*' },
+    });
+    fireEvent.change(screen.getByLabelText(/method/i), {
+      target: { value: 'GET' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(store.getState().ruleset).toHaveLength(1);
+  });
+
+  it('calls onBack when back button clicked', () => {
+    const { onBack } = renderForm('add');
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -18,7 +18,7 @@ const rule: Rule = {
 };
 
 describe('<RuleRow />', () => {
-  const renderRow = (rules: Rule[] = [rule]) => {
+  const renderRow = (rules: Rule[] = [rule], onEdit = jest.fn()) => {
     const store = configureStore({
       reducer: { settings: settingsReducer, ruleset: rulesetReducer },
       preloadedState: { settings: { enableRuleset: false }, ruleset: rules },
@@ -27,7 +27,7 @@ describe('<RuleRow />', () => {
       <Provider store={store}>
         <table>
           <tbody>
-            <RuleRow rule={rules[0]} columns={COLUMN_ORDER} />
+            <RuleRow rule={rules[0]} columns={COLUMN_ORDER} onEdit={onEdit} />
           </tbody>
         </table>
       </Provider>
@@ -60,5 +60,15 @@ describe('<RuleRow />', () => {
     fireEvent.click(deleteButton);
 
     expect(store.getState().ruleset).toHaveLength(0);
+  });
+
+  it('calls onEdit when edit button clicked', () => {
+    const onEdit = jest.fn();
+    renderRow([rule], onEdit);
+
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    expect(onEdit).toHaveBeenCalledWith(rule.id);
   });
 });

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -12,14 +12,14 @@ import settingsReducer from '../../store/settingsSlice';
 import mockRules from '../../mocks/rules.json';
 
 describe('<RuleTable />', () => {
-  const renderRuleTable = (rules: Rule[] = []) => {
+  const renderRuleTable = (rules: Rule[] = [], onEdit = jest.fn()) => {
     const store = configureStore({
       reducer: { settings: settingsReducer, ruleset: rulesetReducer },
       preloadedState: { settings: { enableRuleset: false }, ruleset: rules },
     });
     render(
       <Provider store={store}>
-        <RuleTable />
+        <RuleTable onEdit={onEdit} />
       </Provider>
     );
     return store;
@@ -96,5 +96,15 @@ describe('<RuleTable />', () => {
     expect(rows).toHaveLength(rules.length); // header + remaining row
     expect(screen.queryByText(rules[0].urlPattern)).not.toBeInTheDocument();
     expect(store.getState().ruleset).toHaveLength(1);
+  });
+
+  it('calls onEdit when edit button clicked', () => {
+    const onEdit = jest.fn();
+    renderRuleTable(mockRules.slice(0, 1), onEdit);
+
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    expect(onEdit).toHaveBeenCalledWith(mockRules[0].id);
   });
 });

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -3,12 +3,15 @@ import { useAppDispatch, useAppSelector } from '../../store';
 import { setEnableRuleset } from '../../store/settingsSlice';
 import { addRule } from '../../Panel/ruleset/rulesetSlice';
 
-import RuleTable from '../../components/RuleTable';
+import RuleList from '../../components/RuleList';
+import RuleForm from '../../components/RuleForm';
 import mockData from '../../mocks/rules.json';
-import Filter from '../../components/Filter';
+
+type ViewState = 'list' | 'edit' | 'add';
 
 const App: React.FC = () => {
-  const [filter, setFilter] = useState('');
+  const [view, setView] = useState<ViewState>('list');
+  const [editId, setEditId] = useState<string | null>(null);
   const dispatch = useAppDispatch();
   const enableRuleset = useAppSelector((state) => state.settings.enableRuleset);
   const rules = useAppSelector((state) => state.ruleset);
@@ -32,9 +35,28 @@ const App: React.FC = () => {
         />
         Apply Rules
       </label>
-      <Filter value={filter} onFilterChange={setFilter} />
       <div data-testid="app-container">
-        <RuleTable filter={filter} />
+        {view === 'list' && (
+          <RuleList
+            onEdit={(id) => {
+              setEditId(id);
+              setView('edit');
+            }}
+            onAdd={() => setView('add')}
+          />
+        )}
+
+        {view === 'edit' && (
+          <RuleForm
+            mode="edit"
+            ruleId={editId || undefined}
+            onBack={() => setView('list')}
+          />
+        )}
+
+        {view === 'add' && (
+          <RuleForm mode="add" onBack={() => setView('list')} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `<RuleForm/>` for add/edit actions
- create `<RuleList/>` to list and add rules
- wire new views in panel
- support edit callback in table rows
- test view changes

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for '@testing-library/jest-dom')*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest: not found)*