### PR TITLE
UI updates for rule management

### DIFF
--- a/src/Panel/ruleset/rulesetSlice.ts
+++ b/src/Panel/ruleset/rulesetSlice.ts
@@ -2,7 +2,9 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
 import type { Rule } from '../../types/rule';
 
-type RuleUpdate = Partial<Pick<Rule, 'urlPattern' | 'method' | 'enabled'>>;
+type RuleUpdate = Partial<
+  Pick<Rule, 'urlPattern' | 'method' | 'enabled' | 'response'>
+>;
 
 const initialState: Rule[] = [];
 

--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -17,12 +17,14 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
   const [urlPattern, setUrlPattern] = useState('');
   const [method, setMethod] = useState('GET');
   const [enabled, setEnabled] = useState(true);
+  const [response, setResponse] = useState('');
 
   useEffect(() => {
     if (mode === 'edit' && existing) {
       setUrlPattern(existing.urlPattern);
       setMethod(existing.method);
       setEnabled(existing.enabled);
+      setResponse(existing.response || '');
     }
   }, [existing, mode]);
 
@@ -35,12 +37,15 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
           method,
           enabled,
           date: new Date().toISOString().split('T')[0],
-          response: null,
+          response,
         })
       );
     } else if (mode === 'edit' && ruleId) {
       dispatch(
-        updateRule({ id: ruleId, changes: { urlPattern, method, enabled } })
+        updateRule({
+          id: ruleId,
+          changes: { urlPattern, method, enabled, response },
+        })
       );
     }
     onBack();
@@ -63,12 +68,17 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
         </label>
         <label className="flex flex-col">
           <span>Method</span>
-          <input
-            type="text"
+          <select
             value={method}
             onChange={(e) => setMethod(e.target.value)}
             className="rounded border border-gray-300 px-2 py-1 text-black"
-          />
+          >
+            {['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
         </label>
         <label className="flex items-center gap-2">
           <input
@@ -77,6 +87,15 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
             onChange={(e) => setEnabled(e.target.checked)}
           />
           Enabled
+        </label>
+        <label className="flex flex-col">
+          <span>Response Body</span>
+          <textarea
+            rows={4}
+            value={response}
+            onChange={(e) => setResponse(e.target.value)}
+            className="rounded border border-gray-300 px-2 py-1 text-black"
+          />
         </label>
       </div>
       <div className="space-x-2">

--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import type { Rule } from '../types/rule';
 import { RuleColumn } from './columnConfig';
 import { useAppDispatch } from '../store';
-import { removeRule } from '../Panel/ruleset/rulesetSlice';
+import { removeRule, updateRule } from '../Panel/ruleset/rulesetSlice';
+import ToggleButton from './ToggleButton';
 
 interface RuleRowProps {
   rule: Rule;
@@ -26,9 +27,16 @@ const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
       case RuleColumn.Method:
         return rule.method;
       case RuleColumn.Enabled:
-        return rule.enabled ? 'Yes' : 'No';
-      case RuleColumn.Date:
-        return rule.date;
+        return (
+          <ToggleButton
+            isEnabled={rule.enabled}
+            onToggle={() =>
+              dispatch(
+                updateRule({ id: rule.id, changes: { enabled: !rule.enabled } })
+              )
+            }
+          />
+        );
       case RuleColumn.Actions:
       default:
         return (

--- a/src/components/RuleTable.tsx
+++ b/src/components/RuleTable.tsx
@@ -24,7 +24,7 @@ const RuleTable: React.FC<RuleTableProps> = ({ filter = '', onEdit }) => {
           {COLUMN_ORDER.map((column) => (
             <th
               key={column}
-              className="border-b px-2 py-1 font-semibold text-red-600"
+              className="border-b px-2 py-1 text-left font-semibold text-red-600"
             >
               {COLUMN_LABELS[column]}
             </th>

--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export type ToggleButtonProps = {
+  isEnabled: boolean;
+  onToggle: () => void;
+};
+
+const ToggleButton: React.FC<ToggleButtonProps> = ({ isEnabled, onToggle }) => (
+  <button
+    type="button"
+    onClick={onToggle}
+    className={`px-3 py-1 rounded text-sm font-medium transition ${
+      isEnabled
+        ? 'bg-green-600 text-white hover:bg-green-700'
+        : 'bg-gray-500 text-white hover:bg-gray-600'
+    }`}
+  >
+    {isEnabled ? 'Enabled' : 'Disabled'}
+  </button>
+);
+
+export default ToggleButton;

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -44,8 +44,7 @@ describe('<RuleRow />', () => {
 
     expect(row).toHaveTextContent(rule.urlPattern);
     expect(row).toHaveTextContent(rule.method);
-    expect(row).toHaveTextContent('Yes');
-    expect(row).toHaveTextContent(rule.date);
+    expect(screen.getByRole('button', { name: 'Enabled' })).toBeInTheDocument();
 
     const editButton = screen.getByRole('button', { name: 'Edit' });
     const deleteButton = screen.getByRole('button', { name: 'Delete' });

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -1,7 +1,7 @@
 // src/components/__tests__/RuleTable.test.tsx
 import React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import RuleTable from '../RuleTable';
@@ -62,13 +62,16 @@ describe('<RuleTable />', () => {
 
       expect(row).toHaveTextContent(rule.urlPattern);
       expect(row).toHaveTextContent(rule.method);
-      expect(row).toHaveTextContent(rule.enabled ? 'Yes' : 'No');
-      expect(row).toHaveTextContent(rule.date);
+      expect(
+        within(row).getByRole('button', {
+          name: rule.enabled ? 'Enabled' : 'Disabled',
+        })
+      ).toBeInTheDocument();
 
       const buttons = row.querySelectorAll('button');
-      expect(buttons).toHaveLength(2);
-      expect(buttons[0]).toHaveTextContent('Edit');
-      expect(buttons[1]).toHaveTextContent('Delete');
+      expect(buttons).toHaveLength(3);
+      expect(buttons[1]).toHaveTextContent('Edit');
+      expect(buttons[2]).toHaveTextContent('Delete');
     });
   });
 

--- a/src/components/columnConfig.ts
+++ b/src/components/columnConfig.ts
@@ -1,23 +1,20 @@
 export enum RuleColumn {
+  Enabled = 'enabled',
   UrlPattern = 'urlPattern',
   Method = 'method',
-  Enabled = 'enabled',
-  Date = 'date',
   Actions = 'actions',
 }
 
 export const COLUMN_ORDER: RuleColumn[] = [
+  RuleColumn.Enabled,
   RuleColumn.UrlPattern,
   RuleColumn.Method,
-  RuleColumn.Enabled,
-  RuleColumn.Date,
   RuleColumn.Actions,
 ];
 
 export const COLUMN_LABELS: Record<RuleColumn, string> = {
+  [RuleColumn.Enabled]: 'Status',
   [RuleColumn.UrlPattern]: 'URL Pattern',
   [RuleColumn.Method]: 'Method',
-  [RuleColumn.Enabled]: 'Enabled',
-  [RuleColumn.Date]: 'Date',
   [RuleColumn.Actions]: 'Actions',
 };


### PR DESCRIPTION
## Summary
- allow toggling rule status directly in the table
- reorder table columns and left-align headers
- add response body to the rule form and switch method to a select field
- update tests for new behaviour

![image](https://github.com/user-attachments/assets/5ca83744-59da-49c1-84ae-348a86670c58)
![image](https://github.com/user-attachments/assets/7c310dbc-b95c-415c-b1af-401b858d12f9)

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*