### PR TITLE
Add ExtensionReceivedState with event bus

### DIFF
--- a/src/pages/Content/Intercept/ExtensionReceivedState.ts
+++ b/src/pages/Content/Intercept/ExtensionReceivedState.ts
@@ -1,0 +1,41 @@
+import type { Rule } from '../../../types/rule';
+import { EventBus } from '../../../utils/EventBus';
+
+export interface ExtensionSettings {
+  enableRuleset: boolean;
+}
+
+export interface ExtensionStateData {
+  settings: ExtensionSettings;
+  rules: Rule[];
+}
+
+export enum ExtensionStateEvents {
+  STATE_UPDATED = 'STATE_UPDATED',
+}
+
+interface ExtensionStateEventMap {
+  [ExtensionStateEvents.STATE_UPDATED]: ExtensionStateData;
+}
+
+export class ExtensionReceivedState extends EventBus<ExtensionStateEventMap> {
+  private state: ExtensionStateData;
+
+  constructor(initial?: Partial<ExtensionStateData>) {
+    super();
+    this.state = {
+      settings: { enableRuleset: false },
+      rules: [],
+      ...initial,
+    } as ExtensionStateData;
+  }
+
+  public getState(): ExtensionStateData {
+    return this.state;
+  }
+
+  public updateState(update: Partial<ExtensionStateData>): void {
+    this.state = { ...this.state, ...update };
+    this.emit(ExtensionStateEvents.STATE_UPDATED, this.state);
+  }
+}

--- a/src/pages/Content/Intercept/__tests__/ExtensionReceivedState.test.ts
+++ b/src/pages/Content/Intercept/__tests__/ExtensionReceivedState.test.ts
@@ -1,0 +1,63 @@
+import { ExtensionReceivedState } from '../ExtensionReceivedState';
+
+describe('ExtensionReceivedState', () => {
+  it('provides default state when no initial state is given', () => {
+    const state = new ExtensionReceivedState();
+    expect(state.getState()).toEqual({
+      settings: { enableRuleset: false },
+      rules: [],
+    });
+  });
+
+  it('allows updating and retrieving the state', () => {
+    const state = new ExtensionReceivedState();
+    state.updateState({ settings: { enableRuleset: true } });
+    expect(state.getState().settings.enableRuleset).toBe(true);
+
+    const rules = [
+      {
+        id: '1',
+        urlPattern: '/api',
+        method: 'GET',
+        enabled: true,
+        date: '',
+        response: null,
+      },
+    ];
+    state.updateState({ rules });
+    expect(state.getState().rules).toEqual(rules);
+  });
+
+  it('merges updates with existing state', () => {
+    const state = new ExtensionReceivedState({
+      settings: { enableRuleset: false },
+      rules: [],
+    });
+    state.updateState({ settings: { enableRuleset: true } });
+    state.updateState({
+      rules: [
+        {
+          id: '2',
+          urlPattern: '/test',
+          method: 'POST',
+          enabled: false,
+          date: '',
+          response: null,
+        },
+      ],
+    });
+    expect(state.getState()).toEqual({
+      settings: { enableRuleset: true },
+      rules: [
+        {
+          id: '2',
+          urlPattern: '/test',
+          method: 'POST',
+          enabled: false,
+          date: '',
+          response: null,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- manage settings and rules with `ExtensionReceivedState`
- notify subscribers on state updates via `EventBus`
- update tests for new class name

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: jest not found)*
