### PR TITLE
Add store state broadcasting

### DIFF
--- a/src/store/__tests__/storePersistence.test.ts
+++ b/src/store/__tests__/storePersistence.test.ts
@@ -17,6 +17,12 @@ describe('store persistence', () => {
           set: setMock,
         },
       },
+      tabs: {
+        sendMessage: jest.fn(),
+      },
+      devtools: {
+        inspectedWindow: { tabId: 1 },
+      },
     };
     return { setMock };
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import settingsReducer, { setEnableRuleset } from './settingsSlice';
 import rulesetReducer, { setRules } from '../Panel/ruleset/rulesetSlice';
+import { RuntimeMessage } from '../types/runtimeMessage';
 
 export const store = configureStore({
   reducer: {
@@ -35,11 +36,21 @@ if (typeof chrome !== 'undefined' && chrome.storage?.local) {
   // `previousSettings` and `previousRuleset` track the last values written so
   // we always write the latest state after each dispatch.
   store.subscribe(() => {
-    const { settings, ruleset } = store.getState();
+    const state = store.getState();
+    const { settings, ruleset } = state;
+
     if (previousSettings !== settings || previousRuleset !== ruleset) {
       previousSettings = settings;
       previousRuleset = ruleset;
+
       chrome.storage.local.set({ settings, ruleset });
+
+      if (chrome.tabs && chrome.devtools?.inspectedWindow) {
+        chrome.tabs.sendMessage(chrome.devtools.inspectedWindow.tabId, {
+          action: RuntimeMessage.STATE_UPDATE,
+          state,
+        });
+      }
     }
   });
 }

--- a/src/types/runtimeMessage.ts
+++ b/src/types/runtimeMessage.ts
@@ -1,0 +1,3 @@
+export enum RuntimeMessage {
+  STATE_UPDATE = 'STATE_UPDATE',
+}


### PR DESCRIPTION
## Summary
- send store updates via runtime messaging
- define a `RuntimeMessage` enum for devtools communication
- update store tests to mock new message API

## Testing
- `npm test` *(fails: jest not found)*