### PR TITLE
test(window): expand interception tests

### DIFF
--- a/src/__mocks__/mockXhr.ts
+++ b/src/__mocks__/mockXhr.ts
@@ -1,0 +1,44 @@
+export default class MockXHR {
+  public readyState = 0;
+  public responseText = '';
+  public response: any = '';
+  public status = 0;
+  public onreadystatechange: (() => void) | null = null;
+  public responseURL = '';
+  private listeners: Record<string, Array<() => void>> = {};
+
+  open(method: string, url: string) {
+    this.responseURL = url;
+    this.readyState = 1;
+  }
+
+  send() {
+    setTimeout(() => {
+      this.readyState = 4;
+      this.status = 200;
+      this.response = 'original';
+      this.responseText = 'original';
+      if (this.onreadystatechange) {
+        this.onreadystatechange();
+      }
+      this.dispatchEvent('readystatechange');
+    }, 0);
+  }
+
+  addEventListener(event: string, cb: () => void) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+  }
+
+  removeEventListener(event: string, cb: () => void) {
+    const arr = this.listeners[event];
+    if (arr) {
+      this.listeners[event] = arr.filter((fn) => fn !== cb);
+    }
+  }
+
+  private dispatchEvent(event: string) {
+    const arr = this.listeners[event];
+    if (arr) arr.forEach((fn) => fn.call(this));
+  }
+}

--- a/src/pages/Window/__tests__/intercept.test.ts
+++ b/src/pages/Window/__tests__/intercept.test.ts
@@ -1,0 +1,117 @@
+import { ExtensionReceivedState } from '../ExtensionReceivedState';
+import MockXHR from '../../../__mocks__/mockXhr';
+
+describe('interceptFetch', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+  });
+
+  it('overrides fetch response based on rules', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response('original'));
+    (globalThis as any).fetch = mockFetch;
+    const { interceptFetch } = require('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/test',
+          method: 'GET',
+          enabled: true,
+          date: '',
+          response: 'patched',
+        },
+      ],
+    });
+    interceptFetch(state);
+    const res = await fetch('/test');
+    const text = await res.text();
+    expect(text).toBe('patched');
+  });
+
+  it('does not override fetch when rule is disabled', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response('original'));
+    (globalThis as any).fetch = mockFetch;
+    const { interceptFetch } = require('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/test',
+          method: 'GET',
+          enabled: false,
+          date: '',
+          response: 'patched',
+        },
+      ],
+    });
+    interceptFetch(state);
+    const res = await fetch('/test');
+    const text = await res.text();
+    expect(text).toBe('original');
+  });
+
+  it('overrides XMLHttpRequest response based on rules', () => {
+    (globalThis as any).XMLHttpRequest = MockXHR as any;
+    (globalThis as any).fetch = jest.fn();
+    const { interceptFetch } = require('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/xhr',
+          method: 'GET',
+          enabled: true,
+          date: '',
+          response: 'patched',
+        },
+      ],
+    });
+    interceptFetch(state);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/xhr');
+    const onReady = jest.fn();
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === 4) {
+        onReady();
+        expect(xhr.responseText).toBe('patched');
+      }
+    };
+    xhr.send();
+    jest.runAllTimers();
+    expect(onReady).toHaveBeenCalled();
+  });
+
+  it('does not override XMLHttpRequest when rule is disabled', () => {
+    (globalThis as any).XMLHttpRequest = MockXHR as any;
+    (globalThis as any).fetch = jest.fn();
+    const { interceptFetch } = require('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/xhr',
+          method: 'GET',
+          enabled: false,
+          date: '',
+          response: 'patched',
+        },
+      ],
+    });
+    interceptFetch(state);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/xhr');
+    const onReady = jest.fn();
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === 4) {
+        onReady();
+        expect(xhr.responseText).toBe('original');
+      }
+    };
+    xhr.send();
+    jest.runAllTimers();
+    expect(onReady).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add shared MockXHR class for unit tests
- use globalThis in tests
- verify interception when rules are disabled

## Testing
- `npm test` *(fails: jest not found)*