### PR TITLE
feat(ruleform): split sections and allow empty method

### DIFF
--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -8,6 +8,84 @@ interface RuleFormProps {
   onBack: () => void;
 }
 
+interface MatchingFieldsProps {
+  urlPattern: string;
+  setUrlPattern: (value: string) => void;
+  method: string;
+  setMethod: (value: string) => void;
+}
+
+const MatchingFields: React.FC<MatchingFieldsProps> = ({
+  urlPattern,
+  setUrlPattern,
+  method,
+  setMethod,
+}) => (
+  <fieldset className="flex flex-col gap-2 rounded border p-2">
+    <legend className="text-sm font-semibold">Matching</legend>
+    <label className="flex flex-col">
+      <span>URL Pattern</span>
+      <input
+        type="text"
+        value={urlPattern}
+        onChange={(e) => setUrlPattern(e.target.value)}
+        className="rounded border border-gray-300 px-2 py-1 text-black"
+      />
+    </label>
+    <label className="flex flex-col">
+      <span>Method</span>
+      <select
+        value={method}
+        onChange={(e) => setMethod(e.target.value)}
+        className="rounded border border-gray-300 px-2 py-1 text-black"
+      >
+        <option value="">Match All</option>
+        {['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => (
+          <option key={m} value={m}>
+            {m}
+          </option>
+        ))}
+      </select>
+    </label>
+  </fieldset>
+);
+
+interface OverrideFieldsProps {
+  enabled: boolean;
+  setEnabled: (value: boolean) => void;
+  response: string;
+  setResponse: (value: string) => void;
+}
+
+const OverrideFields: React.FC<OverrideFieldsProps> = ({
+  enabled,
+  setEnabled,
+  response,
+  setResponse,
+}) => (
+  <fieldset className="flex flex-col gap-2 rounded border p-2">
+    <legend className="text-sm font-semibold">Override</legend>
+    <label className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={(e) => setEnabled(e.target.checked)}
+      />
+      Enabled
+    </label>
+    <label className="flex flex-col">
+      <span>Response Body</span>
+      <textarea
+        rows={4}
+        value={response}
+        onChange={(e) => setResponse(e.target.value)}
+        placeholder="Leave empty to use the original response"
+        className="rounded border border-gray-300 px-2 py-1 text-black"
+      />
+    </label>
+  </fieldset>
+);
+
 const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
   const dispatch = useAppDispatch();
   const existing = useAppSelector((state) =>
@@ -15,7 +93,7 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
   );
 
   const [urlPattern, setUrlPattern] = useState('');
-  const [method, setMethod] = useState('GET');
+  const [method, setMethod] = useState('');
   const [enabled, setEnabled] = useState(true);
   const [response, setResponse] = useState('');
 
@@ -56,47 +134,19 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
       <h2 className="text-xl font-bold">
         {mode === 'edit' ? 'Edit Rule' : 'Add Rule'}
       </h2>
-      <div className="flex flex-col gap-2">
-        <label className="flex flex-col">
-          <span>URL Pattern</span>
-          <input
-            type="text"
-            value={urlPattern}
-            onChange={(e) => setUrlPattern(e.target.value)}
-            className="rounded border border-gray-300 px-2 py-1 text-black"
-          />
-        </label>
-        <label className="flex flex-col">
-          <span>Method</span>
-          <select
-            value={method}
-            onChange={(e) => setMethod(e.target.value)}
-            className="rounded border border-gray-300 px-2 py-1 text-black"
-          >
-            {['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => setEnabled(e.target.checked)}
-          />
-          Enabled
-        </label>
-        <label className="flex flex-col">
-          <span>Response Body</span>
-          <textarea
-            rows={4}
-            value={response}
-            onChange={(e) => setResponse(e.target.value)}
-            className="rounded border border-gray-300 px-2 py-1 text-black"
-          />
-        </label>
+      <div className="flex flex-col gap-4">
+        <MatchingFields
+          urlPattern={urlPattern}
+          setUrlPattern={setUrlPattern}
+          method={method}
+          setMethod={setMethod}
+        />
+        <OverrideFields
+          enabled={enabled}
+          setEnabled={setEnabled}
+          response={response}
+          setResponse={setResponse}
+        />
       </div>
       <div className="space-x-2">
         <button type="submit" className="rounded bg-blue-600 px-2 py-1">

--- a/src/components/__tests__/RuleForm.test.tsx
+++ b/src/components/__tests__/RuleForm.test.tsx
@@ -28,6 +28,12 @@ const renderForm = (mode: 'add' | 'edit', preloadedRules: Rule[] = []) => {
 };
 
 describe('<RuleForm />', () => {
+  it('defaults method to empty value in add mode', () => {
+    renderForm('add');
+    expect((screen.getByLabelText(/method/i) as HTMLSelectElement).value).toBe(
+      ''
+    );
+  });
   it('adds a rule when submitted in add mode', () => {
     const { store } = renderForm('add');
 


### PR DESCRIPTION
## Summary
- refactor RuleForm into MatchingFields and OverrideFields components
- allow empty method with "Match All" option
- set method default to blank for new rules
- update test for empty method default

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: jest not found)*