### PR TITLE
Add XHR interception

### DIFF
--- a/src/__mocks__/fakeXHR.ts
+++ b/src/__mocks__/fakeXHR.ts
@@ -1,0 +1,31 @@
+export default class FakeXHR {
+  onload: (() => void) | null = null;
+  onreadystatechange: (() => void) | null = null;
+  readyState = 0;
+  status = 200;
+  response: any = 'orig';
+  responseText: any = 'orig';
+  private method = '';
+  private url = '';
+  private headers: Record<string, string> = {};
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+
+  addEventListener(event: string, cb: () => void) {
+    if (event === 'load') this.onload = cb;
+    if (event === 'readystatechange') this.onreadystatechange = cb;
+  }
+
+  send() {
+    this.readyState = 4;
+    if (this.onreadystatechange) this.onreadystatechange();
+    if (this.onload) this.onload();
+  }
+}

--- a/src/pages/Window/__tests__/intercept.test.ts
+++ b/src/pages/Window/__tests__/intercept.test.ts
@@ -1,0 +1,53 @@
+describe('interceptFetch', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  function setup() {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(new Response('orig', { status: 200 }));
+    (global as any).fetch = fetchMock;
+
+    const { default: FakeXHR } = require('../../__mocks__/fakeXHR');
+    (global as any).XMLHttpRequest = FakeXHR as any;
+
+    return { fetchMock };
+  }
+
+  it('overrides fetch and xhr responses', async () => {
+    const { fetchMock } = setup();
+    const { ExtensionReceivedState } = await import(
+      '../ExtensionReceivedState'
+    );
+    const { interceptFetch } = await import('../intercept');
+
+    const state = new ExtensionReceivedState({
+      settings: { enableRuleset: true },
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/test',
+          method: 'GET',
+          enabled: true,
+          statusCode: 201,
+          date: '',
+          response: 'patched',
+        },
+      ],
+    });
+
+    interceptFetch(state);
+
+    const res = await fetch('/test');
+    expect(fetchMock).toHaveBeenCalled();
+    expect(await res.text()).toBe('patched');
+    expect(res.status).toBe(201);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', '/test');
+    xhr.send();
+    expect(xhr.responseText).toBe('patched');
+    expect(xhr.status).toBe(201);
+  });
+});

--- a/src/utils/globalXMLHttpRequest.ts
+++ b/src/utils/globalXMLHttpRequest.ts
@@ -1,0 +1,7 @@
+const originalXMLHttpRequest = window.XMLHttpRequest;
+
+export const getOriginalXMLHttpRequest = () => originalXMLHttpRequest;
+export const setGlobalXMLHttpRequest = (ctor: typeof XMLHttpRequest) => {
+  window.XMLHttpRequest = ctor;
+};
+export const getGlobalXMLHttpRequest = () => window.XMLHttpRequest;


### PR DESCRIPTION
## Summary
- support XMLHttpRequest interception alongside fetch
- add helper to manage global XMLHttpRequest
- cover intercept logic with tests
- extract FakeXHR mock for reuse

## Testing
- `npm test` *(fails: jest not found)*