### PR TITLE
Persist receiver state across reload

### DIFF
--- a/src/pages/Window/ExtensionReceivedState.ts
+++ b/src/pages/Window/ExtensionReceivedState.ts
@@ -36,6 +36,8 @@ export class ExtensionReceivedState extends EventBus<ExtensionStateEventMap> {
 
   public updateState(update: Partial<ExtensionStateData>): void {
     this.state = { ...this.state, ...update };
+    sessionStorage.setItem('settings', JSON.stringify(this.state.settings));
+    sessionStorage.setItem('ruleset', JSON.stringify(this.state.ruleset));
     this.emit(ExtensionStateEvents.STATE_UPDATED, this.state);
   }
 }

--- a/src/pages/Window/__tests__/ExtensionReceivedState.test.ts
+++ b/src/pages/Window/__tests__/ExtensionReceivedState.test.ts
@@ -64,4 +64,28 @@ describe('ExtensionReceivedState', () => {
       ],
     });
   });
+
+  it('persists state to sessionStorage on update', () => {
+    sessionStorage.clear();
+    const state = new ExtensionReceivedState();
+    state.updateState({ settings: { enableRuleset: true } });
+    state.updateState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/persist',
+          method: 'GET',
+          enabled: true,
+          date: '',
+          response: null,
+          statusCode: 200,
+        },
+      ],
+    });
+    expect(sessionStorage.getItem('settings')).toBe(
+      JSON.stringify({ enableRuleset: true })
+    );
+    const storedRules = JSON.parse(sessionStorage.getItem('ruleset') || '[]');
+    expect(storedRules).toHaveLength(1);
+  });
 });

--- a/src/pages/Window/__tests__/interceptSession.test.ts
+++ b/src/pages/Window/__tests__/interceptSession.test.ts
@@ -1,0 +1,48 @@
+import { ExtensionReceivedState } from '../ExtensionReceivedState';
+import type { Rule } from '../../../types/rule';
+import { setGlobalFetch } from '../../../utils/globalFetch';
+import { initialize, loadSession, update } from '../intercept';
+
+jest.mock('../../../utils/globalFetch', () => {
+  return {
+    getOriginalFetch: jest.fn(() => fetch),
+    setGlobalFetch: jest.fn(),
+  };
+});
+
+describe('intercept session persistence', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    (setGlobalFetch as jest.Mock).mockClear();
+  });
+
+  it('restores interception on reload when previously enabled', () => {
+    const state = new ExtensionReceivedState();
+    state.updateState({ settings: { enableRuleset: true } });
+    state.updateState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/persist',
+          method: 'GET',
+          enabled: true,
+          date: '',
+          response: null,
+          statusCode: 200,
+        },
+      ] as Rule[],
+    });
+    update(state);
+
+    expect(sessionStorage.getItem('patched')).toBe('true');
+
+    const stored = loadSession();
+    const newState = new ExtensionReceivedState({
+      settings: { enableRuleset: stored.patched },
+      ruleset: stored.ruleset,
+    });
+    initialize(newState);
+
+    expect((setGlobalFetch as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/Window/setup.ts
+++ b/src/pages/Window/setup.ts
@@ -1,4 +1,4 @@
-import { interceptFetch } from './intercept';
+import { initialize, loadSession, update } from './intercept';
 import {
   listenContentScriptMessages,
   postMessage,
@@ -13,15 +13,14 @@ import {
   ExtensionMessageOrigin,
 } from '../../types/runtimeMessage';
 export const setup = () => {
-  const extensionStateReceiver = new ExtensionReceivedState();
-  extensionStateReceiver.on(
-    ExtensionStateEvents.STATE_UPDATED,
-    (updatedState) => {
-      if (updatedState) {
-        console.log('[setup] ExtensionReceivedState updated:', updatedState);
-      }
-    }
-  );
+  const stored = loadSession();
+  const extensionStateReceiver = new ExtensionReceivedState({
+    settings: { enableRuleset: stored.patched },
+    ruleset: stored.ruleset,
+  });
+  extensionStateReceiver.on(ExtensionStateEvents.STATE_UPDATED, () => {
+    update(extensionStateReceiver);
+  });
   postMessage({
     action: ExtensionMessageType.RECEIVER_READY,
   });
@@ -34,5 +33,5 @@ export const setup = () => {
       } as Partial<ExtensionStateData>);
     }
   });
-  interceptFetch(extensionStateReceiver);
+  initialize(extensionStateReceiver);
 };


### PR DESCRIPTION
## Summary
- store receiver settings and ruleset in sessionStorage
- restore previous interception when the page reloads
- write updates to session storage from ExtensionReceivedState
- load stored state in the receiver setup
- test state persistence and auto-patching

## Testing
- `npm test`
- `npm run lint`