### PR TITLE
fix: handle sendMessage errors

### DIFF
--- a/src/chrome/index.ts
+++ b/src/chrome/index.ts
@@ -2,7 +2,15 @@
 
 export function safeSendMessage(tabId: number, message: any) {
   if (typeof chrome !== 'undefined' && chrome.tabs && chrome.tabs.sendMessage) {
-    chrome.tabs.sendMessage(tabId, message);
+    try {
+      chrome.tabs.sendMessage(tabId, message);
+    } catch (error) {
+      console.error('[chromeApi] failed to send message', {
+        tabId,
+        message,
+        error,
+      });
+    }
   } else {
     console.error('[chromeApi] chrome.tabs.sendMessage is not available', {
       tabId,

--- a/src/pages/Content/index.ts
+++ b/src/pages/Content/index.ts
@@ -8,10 +8,14 @@ export const listenInjectedScript = () => {
     // Process messages coming from the injected script
     if (event.data.from === ExtensionMessageOrigin.RECEIVER) {
       console.log('[FORWARD-FROM-RECEIVER-TO-DEVTOOLS]', event.data);
-      this.chrome.runtime.sendMessage({
-        source: ExtensionMessageOrigin.CONTENT_SCRIPT,
-        payload: event.data,
-      });
+      try {
+        this.chrome.runtime.sendMessage({
+          source: ExtensionMessageOrigin.CONTENT_SCRIPT,
+          payload: event.data,
+        });
+      } catch (error) {
+        console.error('[Content] Failed to forward message', error);
+      }
     }
   });
 };


### PR DESCRIPTION
## Summary
- wrap `chrome.runtime.sendMessage` in try/catch to log failures
- wrap `chrome.tabs.sendMessage` in try/catch to log failures

## Testing
- `npm run lint:silent`
- `npm test`
