### PR TITLE
Track rule matches in devtools

### DIFF
--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Rule } from '../types/rule';
 import { RuleColumn } from './columnConfig';
-import { useAppDispatch } from '../store';
+import { useAppDispatch, useAppSelector } from '../store';
 import { removeRule, updateRule } from '../Panel/ruleset/rulesetSlice';
 import ToggleButton from './ToggleButton';
 
@@ -13,6 +13,7 @@ interface RuleRowProps {
 
 const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
   const dispatch = useAppDispatch();
+  const matchCount = useAppSelector((state) => state.matches[rule.id] || 0);
   const handleDelete = () => dispatch(removeRule(rule.id));
   const handleEdit = () => onEdit(rule.id);
 
@@ -37,6 +38,8 @@ const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
             }
           />
         );
+      case RuleColumn.Matches:
+        return matchCount;
       case RuleColumn.Actions:
       default:
         return (

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -5,13 +5,22 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
+import matchesReducer from '../../store/matchSlice';
 import type { Rule } from '../../types/rule';
 import mockData from '../../__mocks__/rules.json';
 
 const createStore = (rules: Rule[] = mockData) =>
   configureStore({
-    reducer: { settings: settingsReducer, ruleset: rulesetReducer },
-    preloadedState: { settings: { patched: false }, ruleset: rules },
+    reducer: {
+      settings: settingsReducer,
+      ruleset: rulesetReducer,
+      matches: matchesReducer,
+    },
+    preloadedState: {
+      settings: { patched: false },
+      ruleset: rules,
+      matches: {},
+    },
   });
 
 describe('<App />', () => {

--- a/src/components/__tests__/RuleForm.test.tsx
+++ b/src/components/__tests__/RuleForm.test.tsx
@@ -5,14 +5,20 @@ import { configureStore } from '@reduxjs/toolkit';
 import RuleForm from '../RuleForm';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
+import matchesReducer from '../../store/matchSlice';
 import { Rule } from '../../../src/types/rule';
 
 const renderForm = (mode: 'add' | 'edit', preloadedRules: Rule[] = []) => {
   const store = configureStore({
-    reducer: { settings: settingsReducer, ruleset: rulesetReducer },
+    reducer: {
+      settings: settingsReducer,
+      ruleset: rulesetReducer,
+      matches: matchesReducer,
+    },
     preloadedState: {
       settings: { patched: false },
       ruleset: preloadedRules,
+      matches: {},
     },
   });
 

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -7,6 +7,7 @@ import type { Rule } from '../../types/rule';
 import { COLUMN_ORDER } from '../columnConfig';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
+import matchesReducer from '../../store/matchSlice';
 
 const rule: Rule = {
   id: '1',
@@ -21,8 +22,16 @@ const rule: Rule = {
 describe('<RuleRow />', () => {
   const renderRow = (rules: Rule[] = [rule], onEdit = jest.fn()) => {
     const store = configureStore({
-      reducer: { settings: settingsReducer, ruleset: rulesetReducer },
-      preloadedState: { settings: { patched: false }, ruleset: rules },
+      reducer: {
+        settings: settingsReducer,
+        ruleset: rulesetReducer,
+        matches: matchesReducer,
+      },
+      preloadedState: {
+        settings: { patched: false },
+        ruleset: rules,
+        matches: {},
+      },
     });
     render(
       <Provider store={store}>

--- a/src/components/__tests__/RuleTable.test.tsx
+++ b/src/components/__tests__/RuleTable.test.tsx
@@ -9,13 +9,22 @@ import type { Rule } from '../../types/rule';
 import { COLUMN_ORDER, COLUMN_LABELS } from '../columnConfig';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
+import matchesReducer from '../../store/matchSlice';
 import mockRules from '../../__mocks__/rules.json';
 
 describe('<RuleTable />', () => {
   const renderRuleTable = (rules: Rule[] = [], onEdit = jest.fn()) => {
     const store = configureStore({
-      reducer: { settings: settingsReducer, ruleset: rulesetReducer },
-      preloadedState: { settings: { patched: false }, ruleset: rules },
+      reducer: {
+        settings: settingsReducer,
+        ruleset: rulesetReducer,
+        matches: matchesReducer,
+      },
+      preloadedState: {
+        settings: { patched: false },
+        ruleset: rules,
+        matches: {},
+      },
     });
     render(
       <Provider store={store}>

--- a/src/components/columnConfig.ts
+++ b/src/components/columnConfig.ts
@@ -2,6 +2,7 @@ export enum RuleColumn {
   Enabled = 'enabled',
   UrlPattern = 'urlPattern',
   Method = 'method',
+  Matches = 'matches',
   Actions = 'actions',
 }
 
@@ -9,6 +10,7 @@ export const COLUMN_ORDER: RuleColumn[] = [
   RuleColumn.Enabled,
   RuleColumn.UrlPattern,
   RuleColumn.Method,
+  RuleColumn.Matches,
   RuleColumn.Actions,
 ];
 
@@ -16,5 +18,6 @@ export const COLUMN_LABELS: Record<RuleColumn, string> = {
   [RuleColumn.Enabled]: 'Status',
   [RuleColumn.UrlPattern]: 'URL Pattern',
   [RuleColumn.Method]: 'Method',
+  [RuleColumn.Matches]: 'Matches',
   [RuleColumn.Actions]: 'Actions',
 };

--- a/src/pages/Window/intercept.ts
+++ b/src/pages/Window/intercept.ts
@@ -1,6 +1,8 @@
 import { ExtensionReceivedState } from './ExtensionReceivedState';
 import { getOriginalFetch, setGlobalFetch } from '../../utils/globalFetch';
 import type { Rule } from '../../types/rule';
+import { postMessage } from './contentScriptMessage';
+import { ExtensionMessageType } from '../../types/runtimeMessage';
 
 const mapFetchArguments = (...args: [RequestInfo | URL, RequestInit?]) => {
   const requestInput: RequestInfo | URL = args[0];
@@ -84,6 +86,10 @@ export const interceptFetch = (
         clonedResponse
       );
       if (overridden) {
+        postMessage({
+          action: ExtensionMessageType.RULE_MATCHED,
+          ruleId: rule.id,
+        });
         return overridden;
       }
     }

--- a/src/store/__tests__/matchSlice.test.ts
+++ b/src/store/__tests__/matchSlice.test.ts
@@ -1,0 +1,19 @@
+import reducer, {
+  incrementMatch,
+  resetMatches,
+  MatchCountState,
+} from '../matchSlice';
+
+describe('matchSlice', () => {
+  it('increments match count for rule id', () => {
+    const state: MatchCountState = {};
+    const newState = reducer(state, incrementMatch('abc'));
+    expect(newState['abc']).toBe(1);
+  });
+
+  it('resets match counts', () => {
+    const state: MatchCountState = { abc: 2 };
+    const newState = reducer(state, resetMatches());
+    expect(newState).toEqual({});
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import settingsReducer, { setPatched } from './settingsSlice';
 import rulesetReducer, { setRules } from '../Panel/ruleset/rulesetSlice';
+import matchesReducer, { incrementMatch } from './matchSlice';
 import {
   ExtensionMessageType,
   ExtensionMessageOrigin,
@@ -17,6 +18,7 @@ export const store = configureStore({
   reducer: {
     settings: settingsReducer,
     ruleset: rulesetReducer,
+    matches: matchesReducer,
   },
 });
 
@@ -80,3 +82,11 @@ export const emitExtensionState = async () => {
     console.log('chrome devtools not available, skipping state broadcast');
   }
 };
+
+if (typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.payload?.action === ExtensionMessageType.RULE_MATCHED) {
+      store.dispatch(incrementMatch(message.payload.ruleId));
+    }
+  });
+}

--- a/src/store/matchSlice.ts
+++ b/src/store/matchSlice.ts
@@ -1,0 +1,22 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type MatchCountState = Record<string, number>;
+
+const initialState: MatchCountState = {};
+
+const matchSlice = createSlice({
+  name: 'matches',
+  initialState,
+  reducers: {
+    incrementMatch(state, action: PayloadAction<string>) {
+      const id = action.payload;
+      state[id] = (state[id] || 0) + 1;
+    },
+    resetMatches() {
+      return {} as MatchCountState;
+    },
+  },
+});
+
+export const { incrementMatch, resetMatches } = matchSlice.actions;
+export default matchSlice.reducer;

--- a/src/types/runtimeMessage.ts
+++ b/src/types/runtimeMessage.ts
@@ -1,6 +1,7 @@
 export enum ExtensionMessageType {
   STATE_UPDATE = 'STATE_UPDATE',
   RECEIVER_READY = 'RECEIVER_READY',
+  RULE_MATCHED = 'RULE_MATCHED',
 }
 
 export enum ExtensionMessageOrigin {


### PR DESCRIPTION
## Summary
- add `RULE_MATCHED` message type for runtime messages
- add matches slice to track match counts
- send events when a rule is matched
- listen for RULE_MATCHED events in the store
- display match count in devtools table
- update tests for new slice

## Testing
- `npm run lint`
- `npm test`