### PR TITLE
feat(devtools): unpatch on close

### DIFF
--- a/src/chrome/index.ts
+++ b/src/chrome/index.ts
@@ -3,7 +3,15 @@
 export function safeSendMessage(tabId: number, message: any) {
   if (typeof chrome !== 'undefined' && chrome.tabs && chrome.tabs.sendMessage) {
     try {
-      chrome.tabs.sendMessage(tabId, message);
+      chrome.tabs.sendMessage(tabId, message, (response) => {
+        if (chrome.runtime.lastError) {
+          console.warn('[chromeApi] Error sending message', {
+            tabId,
+            message,
+            error: chrome.runtime.lastError.message,
+          });
+        }
+      });
     } catch (error) {
       console.error('[chromeApi] failed to send message', {
         tabId,

--- a/src/pages/Content/index.ts
+++ b/src/pages/Content/index.ts
@@ -9,16 +9,20 @@ export const listenInjectedScript = () => {
     if (event.data.from === ExtensionMessageOrigin.RECEIVER) {
       console.log('[FORWARD-FROM-RECEIVER-TO-DEVTOOLS]', event.data);
       try {
-        const result = this.chrome.runtime.sendMessage({
-          source: ExtensionMessageOrigin.CONTENT_SCRIPT,
-          payload: event.data,
-        });
-        // Uncomment the following lines for debugging purposes
-        // if (result?.catch) {
-        //   result.catch((err) => {
-        //     console.error("[DEBUG] sendMessage failed:", err);
-        //   });
-        // }
+        this.chrome.runtime.sendMessage(
+          {
+            source: ExtensionMessageOrigin.CONTENT_SCRIPT,
+            payload: event.data,
+          },
+          () => {
+            if (chrome.runtime.lastError) {
+              console.warn(
+                '[Content] Error sending message to devtools:',
+                chrome.runtime.lastError
+              );
+            }
+          }
+        );
       } catch (error) {
         console.error('[Content] Failed to forward message', error);
       }

--- a/src/pages/Devtools/__tests__/unpatchOnClose.test.ts
+++ b/src/pages/Devtools/__tests__/unpatchOnClose.test.ts
@@ -27,13 +27,17 @@ describe('Devtools unload behavior', () => {
 
     window.dispatchEvent(new Event('beforeunload'));
 
-    expect(sendMessageMock).toHaveBeenCalledWith(1, {
-      action: ExtensionMessageType.STATE_UPDATE,
-      from: ExtensionMessageOrigin.DEVTOOLS,
-      state: {
-        settings: { patched: false },
-        ruleset: [],
-      },
-    });
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        action: ExtensionMessageType.STATE_UPDATE,
+        from: ExtensionMessageOrigin.DEVTOOLS,
+        state: {
+          settings: { patched: false },
+          ruleset: [],
+        },
+      }),
+      expect.anything()
+    );
   });
 });

--- a/src/pages/Devtools/__tests__/unpatchOnClose.test.ts
+++ b/src/pages/Devtools/__tests__/unpatchOnClose.test.ts
@@ -1,0 +1,39 @@
+import {
+  ExtensionMessageType,
+  ExtensionMessageOrigin,
+} from '../../../types/runtimeMessage';
+
+declare const require: any;
+
+describe('Devtools unload behavior', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('sends state update when window is closing', () => {
+    const sendMessageMock = jest.fn();
+    (globalThis as any).chrome = {
+      tabs: { sendMessage: sendMessageMock },
+      devtools: {
+        inspectedWindow: { tabId: 1 },
+        panels: { create: jest.fn() },
+      },
+      runtime: { onMessage: { addListener: jest.fn() } },
+    };
+
+    jest.isolateModules(() => {
+      require('../index');
+    });
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(sendMessageMock).toHaveBeenCalledWith(1, {
+      action: ExtensionMessageType.STATE_UPDATE,
+      from: ExtensionMessageOrigin.DEVTOOLS,
+      state: {
+        settings: { patched: false },
+        ruleset: [],
+      },
+    });
+  });
+});

--- a/src/pages/Devtools/index.ts
+++ b/src/pages/Devtools/index.ts
@@ -3,6 +3,10 @@ import {
   ExtensionMessageType,
   ExtensionMessageOrigin,
 } from '../../../src/types/runtimeMessage';
+import {
+  safeDevtoolsInspectedWindow,
+  safeSendMessage,
+} from '../../../src/chrome';
 
 chrome.devtools.panels.create(
   'Override Response Tool',
@@ -15,5 +19,19 @@ chrome.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
     if (message.payload.action === ExtensionMessageType.RECEIVER_READY) {
       emitExtensionState();
     }
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  const inspectedWindow = safeDevtoolsInspectedWindow();
+  if (chrome.tabs && inspectedWindow) {
+    safeSendMessage(inspectedWindow.tabId, {
+      action: ExtensionMessageType.STATE_UPDATE,
+      from: ExtensionMessageOrigin.DEVTOOLS,
+      state: {
+        settings: { patched: false },
+        ruleset: [],
+      },
+    });
   }
 });

--- a/src/pages/Window/contentScriptMessage.ts
+++ b/src/pages/Window/contentScriptMessage.ts
@@ -13,7 +13,7 @@ export const postMessage = <T extends PostMessagePayload>(payload: T) => {
   try {
     window.postMessage(message, '*');
   } catch (error) {
-    console.error('Error posting message:', error);
+    console.log('Error posting message:', error);
   }
 };
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -70,13 +70,21 @@ store.subscribe(() => {
 
 export const emitExtensionState = async () => {
   console.log('Emitting initial state to devtools panel');
-  const state = await safeGetStorageLocal(null);
+  const { ruleset, settings } = await safeGetStorageLocal([
+    'ruleset',
+    'settings',
+  ]);
   const inspectedWindow = safeDevtoolsInspectedWindow();
   if (chrome.tabs && inspectedWindow) {
     safeSendMessage(inspectedWindow.tabId, {
       action: ExtensionMessageType.STATE_UPDATE,
       from: ExtensionMessageOrigin.DEVTOOLS,
-      state,
+      state: {
+        ruleset: ruleset ?? [],
+        settings: {
+          patched: settings?.patched ?? false,
+        },
+      },
     });
   } else {
     console.log('chrome devtools not available, skipping state broadcast');


### PR DESCRIPTION
## Summary
- reset patched state when devtools window closes
- add regression test for unpatching on close

## Testing
- `npm run lint`
- `npm test`
