### PR TITLE
Fix NPM warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@types/uuid": "^10.0.0",
         "@types/webpack": "^5.28.5",
         "autoprefixer": "^10.4.16",
-        "babel-eslint": "^10.1.0",
+        "@babel/eslint-parser": "^7.19.1",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.2",
         "babel-preset-react-app": "^10.0.1",
@@ -5563,27 +5563,6 @@
       "dev": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/babel-jest": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/testing-library__react": "^10.2.0",
     "@types/uuid": "^10.0.0",
     "@types/webpack": "^5.28.5",
-    "babel-eslint": "^10.1.0",
+    "@babel/eslint-parser": "^7.19.1",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.2",
     "babel-preset-react-app": "^10.0.1",


### PR DESCRIPTION
## Summary
- replace deprecated `babel-eslint` with `@babel/eslint-parser`
- remove extraneous node modules

## Testing
- `npm run lint`
- `npm test`
