### PR TITLE
feat: hide filter below threshold

### DIFF
--- a/.changeset/short-rocks-cut.md
+++ b/.changeset/short-rocks-cut.md
@@ -1,0 +1,5 @@
+---
+'override-response-tool': minor
+---
+
+only show the filter bar whenever there is more than 10 rows

--- a/src/components/RuleList.tsx
+++ b/src/components/RuleList.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Filter from './Filter';
 import RuleTable from './RuleTable';
+import { useAppSelector } from '../store';
 
 interface RuleListProps {
   onEdit: (id: string) => void;
@@ -9,10 +10,13 @@ interface RuleListProps {
 
 const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
   const [filter, setFilter] = useState('');
+  const rulesCount = useAppSelector((state) => state.ruleset.length);
   return (
     <div className="space-y-4">
       <div className="flex justify-end gap-2">
-        <Filter value={filter} onFilterChange={setFilter} />
+        {rulesCount > 10 && (
+          <Filter value={filter} onFilterChange={setFilter} />
+        )}
         <button
           type="button"
           onClick={onAdd}

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -9,6 +9,14 @@ import matchesReducer from '../../store/matchSlice';
 import type { Rule } from '../../types/rule';
 import mockData from '../../__mocks__/rules.json';
 
+const manyRules: Rule[] = [
+  ...mockData,
+  ...Array.from({ length: 7 }, (_, i) => ({
+    ...mockData[0],
+    id: `extra-${i}`,
+  })),
+];
+
 const createStore = (rules: Rule[] = mockData) =>
   configureStore({
     reducer: {
@@ -37,7 +45,7 @@ describe('<App />', () => {
 
   it('filters rules based on url', () => {
     jest.useFakeTimers();
-    const store = createStore();
+    const store = createStore(manyRules);
     render(
       <Provider store={store}>
         <App />
@@ -59,7 +67,7 @@ describe('<App />', () => {
   });
 
   it('clears the filter and shows all rules', () => {
-    const store = createStore();
+    const store = createStore(manyRules);
     render(
       <Provider store={store}>
         <App />
@@ -72,7 +80,7 @@ describe('<App />', () => {
     fireEvent.click(clearButton);
 
     const rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(mockData.length + 1);
+    expect(rows).toHaveLength(manyRules.length + 1);
   });
 
   it('toggles interception button', () => {


### PR DESCRIPTION
## Summary
- only display the filter when there are more than 10 rules
- adjust tests for the new filter behaviour

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6839c9465180832087aca54429454af5