### PR TITLE
Add rule import/export

### DIFF
--- a/.changeset/append-import-rules.md
+++ b/.changeset/append-import-rules.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': patch
+---
+
+append imported rules when importing

--- a/.changeset/quiet-owls-walk.md
+++ b/.changeset/quiet-owls-walk.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': patch
+---
+
+display import/export messages inline

--- a/.changeset/refactor-rule-import-export.md
+++ b/.changeset/refactor-rule-import-export.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': patch
+---
+
+split RuleImportExport into smaller components

--- a/.changeset/shiny-snakes-polish.md
+++ b/.changeset/shiny-snakes-polish.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': patch
+---
+
+style import/export status message below buttons with auto-dismiss

--- a/.changeset/tidy-vans-yawn.md
+++ b/.changeset/tidy-vans-yawn.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': minor
+---
+
+support importing and exporting rules via json

--- a/.changeset/warm-ducks-return.md
+++ b/.changeset/warm-ducks-return.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': patch
+---
+
+move rule import/export logic into separate component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # override-response-tool
 
+## 1.6.0
+
+### Minor Changes
+
+- bfac988: add delay to interption
+
 ## 1.5.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-mocky",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Chrome extension to override fetch/XHR responses",
   "license": "MIT",
   "repository": {

--- a/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
+++ b/src/Panel/ruleset/__tests__/rulesetSlice.test.ts
@@ -18,6 +18,7 @@ describe('rulesetSlice', () => {
       statusCode: 200,
       date: '2024-01-01',
       response: null,
+      delayMs: null,
     },
     {
       id: '2',
@@ -28,6 +29,7 @@ describe('rulesetSlice', () => {
       statusCode: 200,
       date: '2024-02-01',
       response: null,
+      delayMs: null,
     },
   ];
 
@@ -40,6 +42,7 @@ describe('rulesetSlice', () => {
       statusCode: 200,
       date: '2024-03-01',
       response: null,
+      delayMs: null,
     };
     const state = reducer(initialState, addRule(newRule));
     expect(state).toHaveLength(3);
@@ -86,6 +89,7 @@ describe('rulesetSlice', () => {
         statusCode: 200,
         date: '2024-04-01',
         response: null,
+        delayMs: null,
       },
     ];
     const state = reducer(initialState, setRules(replacement));

--- a/src/Panel/ruleset/rulesetSlice.ts
+++ b/src/Panel/ruleset/rulesetSlice.ts
@@ -5,7 +5,13 @@ import type { Rule } from '../../types/rule';
 type RuleUpdate = Partial<
   Pick<
     Rule,
-    'urlPattern' | 'method' | 'enabled' | 'response' | 'statusCode' | 'isRegExp'
+    | 'urlPattern'
+    | 'method'
+    | 'enabled'
+    | 'response'
+    | 'statusCode'
+    | 'isRegExp'
+    | 'delayMs'
   >
 >;
 

--- a/src/__mocks__/rules.json
+++ b/src/__mocks__/rules.json
@@ -7,7 +7,8 @@
     "enabled": true,
     "statusCode": 200,
     "date": "2024-01-01",
-    "response": null
+    "response": null,
+    "delayMs": null
   },
   {
     "id": "2",
@@ -17,7 +18,8 @@
     "enabled": false,
     "statusCode": 200,
     "date": "2024-02-10",
-    "response": null
+    "response": null,
+    "delayMs": null
   },
   {
     "id": "3",
@@ -27,7 +29,8 @@
     "enabled": true,
     "statusCode": 200,
     "date": "2024-03-15",
-    "response": null
+    "response": null,
+    "delayMs": null
   },
   {
     "id": "4",
@@ -37,6 +40,7 @@
     "enabled": true,
     "statusCode": 200,
     "date": "2024-04-01",
-    "response": "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"hello,\",\n  \"completed\": false\n}"
+    "response": "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"hello,\",\n  \"completed\": false\n}",
+    "delayMs": null
   }
 ]

--- a/src/components/OptionsFields.tsx
+++ b/src/components/OptionsFields.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 export interface OptionsFieldsProps {
   enabled: boolean;
   setEnabled: (value: boolean) => void;
+  delayMs?: number | null;
+  setDelayMs: (value: number | null) => void;
 }
 
 const OptionsFields: React.FC<OptionsFieldsProps> = ({
   enabled,
   setEnabled,
+  delayMs,
+  setDelayMs,
 }) => (
   <fieldset className="flex flex-col gap-2 rounded border p-2">
     <legend className="text-sm font-semibold">Options</legend>
@@ -18,6 +22,26 @@ const OptionsFields: React.FC<OptionsFieldsProps> = ({
         onChange={(e) => setEnabled(e.target.checked)}
       />
       Enable Rule
+    </label>
+    <label className="flex flex-col">
+      <span>Delay (ms)</span>
+      <input
+        type="number"
+        min={0}
+        max={10000}
+        value={delayMs ?? ''}
+        onChange={(e) => {
+          const raw = e.target.value;
+          if (raw === '') {
+            setDelayMs(null);
+          } else {
+            const num = Math.min(10000, Number(raw));
+            setDelayMs(num);
+          }
+        }}
+        className="rounded border border-gray-300 px-2 py-1 text-black"
+      />
+      <span className="text-sm">Leave empty for no delay. Max 10000ms.</span>
     </label>
   </fieldset>
 );

--- a/src/components/RuleExportButton.tsx
+++ b/src/components/RuleExportButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { Rule } from '../types/rule';
+
+interface RuleExportButtonProps {
+  rules: Rule[];
+  onMessage: (msg: string) => void;
+}
+
+const RuleExportButton: React.FC<RuleExportButtonProps> = ({
+  rules,
+  onMessage,
+}) => {
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(rules, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'httpmocky-rules.json';
+    a.click();
+    URL.revokeObjectURL(url);
+    onMessage('Rules exported successfully');
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      className="rounded bg-blue-500 px-2 py-1"
+    >
+      Export Rules
+    </button>
+  );
+};
+
+export default RuleExportButton;

--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -115,6 +115,7 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
   const [isRegExp, setIsRegExp] = useState(false);
   const [method, setMethod] = useState('');
   const [enabled, setEnabled] = useState(true);
+  const [delayMs, setDelayMs] = useState<number | null>(null);
   const [response, setResponse] = useState('');
   const [statusCode, setStatusCode] = useState(200);
   const [patternError, setPatternError] = useState<string | null>(null);
@@ -127,6 +128,7 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
       setEnabled(existing.enabled);
       setResponse(existing.response || '');
       setStatusCode(existing.statusCode ?? 200);
+      setDelayMs(existing.delayMs ?? null);
     }
   }, [existing, mode]);
 
@@ -164,6 +166,7 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
           date: new Date().toISOString().split('T')[0],
           response,
           statusCode,
+          delayMs,
         })
       );
     } else if (mode === 'edit' && ruleId) {
@@ -177,6 +180,7 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
             enabled,
             response,
             statusCode,
+            delayMs,
           },
         })
       );
@@ -199,7 +203,12 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
           method={method}
           setMethod={setMethod}
         />
-        <OptionsFields enabled={enabled} setEnabled={setEnabled} />
+        <OptionsFields
+          enabled={enabled}
+          setEnabled={setEnabled}
+          delayMs={delayMs ?? null}
+          setDelayMs={setDelayMs}
+        />
         <OverrideFields
           response={response}
           setResponse={setResponse}

--- a/src/components/RuleImportConfirm.tsx
+++ b/src/components/RuleImportConfirm.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface RuleImportConfirmProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const RuleImportConfirm: React.FC<RuleImportConfirmProps> = ({
+  onConfirm,
+  onCancel,
+}) => (
+  <div className="my-2 flex items-center gap-2">
+    <span>Overwrite existing rules with imported ones?</span>
+    <button
+      type="button"
+      onClick={onConfirm}
+      className="rounded bg-blue-500 px-2 py-1"
+    >
+      Confirm
+    </button>
+    <button
+      type="button"
+      onClick={onCancel}
+      className="rounded bg-gray-300 px-2 py-1"
+    >
+      Cancel
+    </button>
+  </div>
+);
+
+export default RuleImportConfirm;

--- a/src/components/RuleImportExport.tsx
+++ b/src/components/RuleImportExport.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAppDispatch } from '../store';
 import { setRules } from '../Panel/ruleset/rulesetSlice';
 import type { Rule } from '../types/rule';
@@ -14,6 +14,13 @@ const RuleImportExport: React.FC<RuleImportExportProps> = ({ rules }) => {
   const dispatch = useAppDispatch();
   const [message, setMessage] = useState('');
   const [pendingImport, setPendingImport] = useState<Rule[] | null>(null);
+
+  useEffect(() => {
+    if (message) {
+      const timer = setTimeout(() => setMessage(''), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [message]);
 
   const handleImported = (imported: Rule[]) => {
     if (rules.length) {
@@ -42,19 +49,23 @@ const RuleImportExport: React.FC<RuleImportExportProps> = ({ rules }) => {
 
   return (
     <>
-      {message && (
-        <p role="status" className="text-sm text-blue-700">
-          {message}
-        </p>
-      )}
       {pendingImport && (
         <RuleImportConfirm
           onConfirm={handleConfirmImport}
           onCancel={handleCancelImport}
         />
       )}
-      <RuleExportButton rules={rules} onMessage={setMessage} />
-      <RuleImportInput onParsed={handleImported} onError={handleError} />
+      <div className="flex flex-col items-end">
+        <div className="flex gap-2">
+          <RuleExportButton rules={rules} onMessage={setMessage} />
+          <RuleImportInput onParsed={handleImported} onError={handleError} />
+        </div>
+        {message && (
+          <p role="status" className="mt-2 block text-sm text-blue-500">
+            {message}
+          </p>
+        )}
+      </div>
     </>
   );
 };

--- a/src/components/RuleImportExport.tsx
+++ b/src/components/RuleImportExport.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useAppDispatch } from '../store';
+import { setRules } from '../Panel/ruleset/rulesetSlice';
+import type { Rule } from '../types/rule';
+import RuleExportButton from './RuleExportButton';
+import RuleImportInput from './RuleImportInput';
+import RuleImportConfirm from './RuleImportConfirm';
+
+interface RuleImportExportProps {
+  rules: Rule[];
+}
+
+const RuleImportExport: React.FC<RuleImportExportProps> = ({ rules }) => {
+  const dispatch = useAppDispatch();
+  const [message, setMessage] = useState('');
+  const [pendingImport, setPendingImport] = useState<Rule[] | null>(null);
+
+  const handleImported = (imported: Rule[]) => {
+    if (rules.length) {
+      setPendingImport(imported);
+    } else {
+      dispatch(setRules([...rules, ...imported]));
+      setMessage('Rules imported successfully');
+    }
+  };
+
+  const handleError = (msg: string) => {
+    setMessage(msg);
+  };
+
+  const handleConfirmImport = () => {
+    if (pendingImport) {
+      dispatch(setRules([...rules, ...pendingImport]));
+      setMessage('Rules imported successfully');
+      setPendingImport(null);
+    }
+  };
+
+  const handleCancelImport = () => {
+    setPendingImport(null);
+  };
+
+  return (
+    <>
+      {message && (
+        <p role="status" className="text-sm text-blue-700">
+          {message}
+        </p>
+      )}
+      {pendingImport && (
+        <RuleImportConfirm
+          onConfirm={handleConfirmImport}
+          onCancel={handleCancelImport}
+        />
+      )}
+      <RuleExportButton rules={rules} onMessage={setMessage} />
+      <RuleImportInput onParsed={handleImported} onError={handleError} />
+    </>
+  );
+};
+
+export default RuleImportExport;

--- a/src/components/RuleImportInput.tsx
+++ b/src/components/RuleImportInput.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import type { Rule } from '../types/rule';
+
+interface RuleImportInputProps {
+  onParsed: (rules: Rule[]) => void;
+  onError: (msg: string) => void;
+}
+
+const RuleImportInput: React.FC<RuleImportInputProps> = ({
+  onParsed,
+  onError,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const validateRule = (rule: Partial<Rule>): rule is Rule =>
+    typeof rule.urlPattern === 'string' &&
+    typeof rule.method === 'string' &&
+    typeof rule.enabled === 'boolean' &&
+    typeof rule.statusCode === 'number';
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const json = JSON.parse(reader.result as string);
+        if (Array.isArray(json) && json.every(validateRule)) {
+          const imported: Rule[] = json.map((r) => ({
+            id: r.id ?? uuidv4(),
+            urlPattern: r.urlPattern,
+            isRegExp: r.isRegExp ?? false,
+            method: r.method,
+            enabled: r.enabled,
+            statusCode: r.statusCode,
+            date: r.date ?? new Date().toISOString().split('T')[0],
+            response: r.response ?? null,
+          }));
+          onParsed(imported);
+        } else {
+          onError('Invalid rules file');
+        }
+      } catch {
+        onError('Failed to parse rules file');
+      }
+      e.target.value = '';
+    };
+    reader.readAsText(file);
+  };
+
+  const triggerImport = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        onChange={handleFileChange}
+        className="hidden"
+      />
+      <button
+        type="button"
+        onClick={triggerImport}
+        className="rounded bg-blue-500 px-2 py-1"
+      >
+        Import Rules
+      </button>
+    </>
+  );
+};
+
+export default RuleImportInput;

--- a/src/components/RuleImportInput.tsx
+++ b/src/components/RuleImportInput.tsx
@@ -17,7 +17,10 @@ const RuleImportInput: React.FC<RuleImportInputProps> = ({
     typeof rule.urlPattern === 'string' &&
     typeof rule.method === 'string' &&
     typeof rule.enabled === 'boolean' &&
-    typeof rule.statusCode === 'number';
+    typeof rule.statusCode === 'number' &&
+    (rule.delayMs === undefined ||
+      rule.delayMs === null ||
+      typeof rule.delayMs === 'number');
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -38,6 +41,7 @@ const RuleImportInput: React.FC<RuleImportInputProps> = ({
             statusCode: r.statusCode,
             date: r.date ?? new Date().toISOString().split('T')[0],
             response: r.response ?? null,
+            delayMs: r.delayMs ?? null,
           }));
           onParsed(imported);
         } else {

--- a/src/components/RuleList.tsx
+++ b/src/components/RuleList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Filter from './Filter';
 import RuleTable from './RuleTable';
 import { useAppSelector } from '../store';
+import RuleImportExport from './RuleImportExport';
 
 interface RuleListProps {
   onEdit: (id: string) => void;
@@ -10,7 +11,9 @@ interface RuleListProps {
 
 const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
   const [filter, setFilter] = useState('');
-  const rulesCount = useAppSelector((state) => state.ruleset.length);
+  const rules = useAppSelector((state) => state.ruleset);
+  const rulesCount = rules.length;
+
   return (
     <div className="space-y-4">
       <div className="flex justify-end gap-2">
@@ -24,6 +27,7 @@ const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
         >
           Add Rule
         </button>
+        <RuleImportExport rules={rules} />
       </div>
       <RuleTable filter={filter} onEdit={onEdit} />
     </div>

--- a/src/components/__tests__/RuleImportExport.test.tsx
+++ b/src/components/__tests__/RuleImportExport.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import RuleImportExport from '../RuleImportExport';
+import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
+import settingsReducer from '../../store/settingsSlice';
+import matchesReducer from '../../store/matchSlice';
+import type { Rule } from '../../types/rule';
+
+const createStore = (rules: Rule[] = []) =>
+  configureStore({
+    reducer: {
+      settings: settingsReducer,
+      ruleset: rulesetReducer,
+      matches: matchesReducer,
+    },
+    preloadedState: {
+      settings: { patched: false },
+      ruleset: rules,
+      matches: {},
+    },
+  });
+
+describe('<RuleImportExport />', () => {
+  it('exports rules using URL.createObjectURL', () => {
+    const rules: Rule[] = [
+      {
+        id: '1',
+        urlPattern: '/api',
+        isRegExp: false,
+        method: 'GET',
+        enabled: true,
+        statusCode: 200,
+        date: '2024-01-01',
+        response: null,
+      },
+    ];
+    const store = createStore(rules);
+    const createObjectURL = jest.fn().mockReturnValue('blob:url');
+    (URL as any).createObjectURL = createObjectURL;
+    (URL as any).revokeObjectURL = jest.fn();
+    render(
+      <Provider store={store}>
+        <RuleImportExport rules={rules} />
+      </Provider>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Export Rules' }));
+    expect(createObjectURL).toHaveBeenCalled();
+  });
+
+  it('imports rules from a JSON file', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <RuleImportExport rules={[]} />
+      </Provider>
+    );
+    const file = new File(
+      [
+        JSON.stringify([
+          {
+            urlPattern: '/api',
+            method: 'GET',
+            enabled: true,
+            statusCode: 200,
+          },
+        ]),
+      ],
+      'rules.json',
+      { type: 'application/json' }
+    );
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const reader: any = {
+      onload: null,
+      result: '',
+      readAsText() {
+        reader.result = JSON.stringify([
+          { urlPattern: '/api', method: 'GET', enabled: true, statusCode: 200 },
+        ]);
+        if (reader.onload) {
+          reader.onload({} as ProgressEvent<FileReader>);
+        }
+      },
+    };
+    jest.spyOn(window as any, 'FileReader').mockImplementation(() => reader);
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(store.getState().ruleset).toHaveLength(1);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Rules imported successfully'
+    );
+  });
+
+  it('confirms before overwriting existing rules', () => {
+    const initial: Rule[] = [
+      {
+        id: '1',
+        urlPattern: '/api',
+        isRegExp: false,
+        method: 'GET',
+        enabled: true,
+        statusCode: 200,
+        date: '2024-01-01',
+        response: null,
+      },
+    ];
+    const store = createStore(initial);
+    render(
+      <Provider store={store}>
+        <RuleImportExport rules={initial} />
+      </Provider>
+    );
+    const file = new File(
+      [
+        JSON.stringify([
+          {
+            urlPattern: '/other',
+            method: 'POST',
+            enabled: true,
+            statusCode: 201,
+          },
+        ]),
+      ],
+      'rules.json',
+      { type: 'application/json' }
+    );
+    const fileInput = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const reader: any = {
+      onload: null,
+      result: '',
+      readAsText() {
+        reader.result = JSON.stringify([
+          {
+            urlPattern: '/other',
+            method: 'POST',
+            enabled: true,
+            statusCode: 201,
+          },
+        ]);
+        if (reader.onload) {
+          reader.onload({} as ProgressEvent<FileReader>);
+        }
+      },
+    };
+    jest.spyOn(window as any, 'FileReader').mockImplementation(() => reader);
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    expect(
+      screen.getByText('Overwrite existing rules with imported ones?')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(store.getState().ruleset).toHaveLength(2);
+    expect(store.getState().ruleset[1].urlPattern).toBe('/other');
+  });
+});

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -18,6 +18,7 @@ const rule: Rule = {
   statusCode: 200,
   date: '2024-01-01',
   response: null,
+  delayMs: null,
 };
 
 describe('<RuleRow />', () => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "HTTPMocky",
   "description": "DevTools panel + content script that rewrites fetch/XHR responses",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "devtools_page": "devtools.html",
   "background": {
     "service_worker": "background.bundle.js"
@@ -10,30 +10,18 @@
   "icons": {
     "128": "icon-128.png"
   },
-  "permissions": [
-    "storage"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "contentScript.bundle.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.bundle.js"],
       "run_at": "document_start",
       "world": "ISOLATED"
     },
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "window.bundle.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["window.bundle.js"],
       "world": "MAIN",
       "run_at": "document_start"
     }

--- a/src/pages/Window/__tests__/applyRule.test.ts
+++ b/src/pages/Window/__tests__/applyRule.test.ts
@@ -40,6 +40,7 @@ describe('applyRule', () => {
       statusCode: 201,
       date: '',
       response: 'override',
+      delayMs: null,
     };
     const result = applyRule(
       { requestUrl: '/v1/api/test', requestMethod: 'GET', requestHeaders: {} },
@@ -61,6 +62,7 @@ describe('applyRule', () => {
       statusCode: 200,
       date: '',
       response: null,
+      delayMs: null,
     };
     const result = applyRule(
       { requestUrl: '/items/42', requestMethod: 'GET', requestHeaders: {} },
@@ -80,6 +82,7 @@ describe('applyRule', () => {
       statusCode: 200,
       date: '',
       response: null,
+      delayMs: null,
     };
     const result = applyRule(
       { requestUrl: '/test', requestMethod: 'GET', requestHeaders: {} },

--- a/src/pages/Window/__tests__/applyXhrRule.test.ts
+++ b/src/pages/Window/__tests__/applyXhrRule.test.ts
@@ -12,6 +12,7 @@ describe('applyXhrRule', () => {
       statusCode: 200,
       date: '',
       response: 'override',
+      delayMs: null,
     };
     const result = applyXhrRule(
       { requestUrl: '/v1/api/test', requestMethod: 'GET' },
@@ -31,6 +32,7 @@ describe('applyXhrRule', () => {
       statusCode: 200,
       date: '',
       response: null,
+      delayMs: null,
     };
     const result = applyXhrRule(
       { requestUrl: '/items/42', requestMethod: 'GET' },
@@ -50,6 +52,7 @@ describe('applyXhrRule', () => {
       statusCode: 200,
       date: '',
       response: null,
+      delayMs: null,
     };
     const result = applyXhrRule(
       { requestUrl: '/test', requestMethod: 'GET' },

--- a/src/pages/Window/__tests__/interceptFetch.test.ts
+++ b/src/pages/Window/__tests__/interceptFetch.test.ts
@@ -1,0 +1,130 @@
+import { ExtensionReceivedState } from '../ExtensionReceivedState';
+import type { Rule } from '../../../types/rule';
+import { ExtensionMessageType } from '../../../types/runtimeMessage';
+
+class FakeResponse {
+  body: any;
+  status: number;
+  statusText: string;
+  headers: any;
+  constructor(
+    body: any,
+    init: { status: number; statusText?: string; headers?: any }
+  ) {
+    this.body = body;
+    this.status = init.status;
+    this.statusText = init.statusText ?? '';
+    this.headers = init.headers;
+  }
+  clone() {
+    return new FakeResponse(this.body, {
+      status: this.status,
+      statusText: this.statusText,
+      headers: this.headers,
+    });
+  }
+  text() {
+    return Promise.resolve(String(this.body));
+  }
+}
+
+(globalThis as any).Response = FakeResponse;
+
+jest.mock('../contentScriptMessage', () => ({
+  postMessage: jest.fn(),
+}));
+
+describe('interceptFetch', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest.fn(() =>
+      Promise.resolve(new Response('orig', { status: 200 }))
+    );
+    (globalThis as any).fetch = fetchMock;
+    (globalThis as any).Request = class MockRequest {};
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+    delete (globalThis as any).Request;
+    jest.useRealTimers();
+  });
+
+  it('delays returning the overridden response', async () => {
+    const { interceptFetch } = await import('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/match',
+          isRegExp: false,
+          method: 'GET',
+          enabled: true,
+          statusCode: 200,
+          date: '',
+          response: 'override',
+          delayMs: 200,
+        } as Rule,
+      ],
+    });
+    interceptFetch(state);
+
+    const resultPromise = fetch('/match');
+    let resolved = false;
+    resultPromise.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    jest.advanceTimersByTime(199);
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    jest.advanceTimersByTime(1);
+    const response = await resultPromise;
+    expect(await response.text()).toBe('override');
+    const { postMessage } = await import('../contentScriptMessage');
+    expect((postMessage as jest.Mock).mock.calls[0][0]).toEqual({
+      action: ExtensionMessageType.RULE_MATCHED,
+      ruleId: '1',
+    });
+  });
+
+  it('caps the delay at 10000ms', async () => {
+    const { interceptFetch } = await import('../intercept');
+    const state = new ExtensionReceivedState({
+      ruleset: [
+        {
+          id: '1',
+          urlPattern: '/match',
+          isRegExp: false,
+          method: 'GET',
+          enabled: true,
+          statusCode: 200,
+          date: '',
+          response: 'override',
+          delayMs: 50000,
+        } as Rule,
+      ],
+    });
+    interceptFetch(state);
+
+    const resultPromise = fetch('/match');
+    let resolved = false;
+    resultPromise.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    jest.advanceTimersByTime(9999);
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    jest.advanceTimersByTime(1);
+    const response = await resultPromise;
+    expect(await response.text()).toBe('override');
+  });
+});

--- a/src/pages/Window/__tests__/interceptSession.test.ts
+++ b/src/pages/Window/__tests__/interceptSession.test.ts
@@ -30,6 +30,7 @@ describe('intercept session persistence', () => {
           date: '',
           response: null,
           statusCode: 200,
+          delayMs: null,
         },
       ] as Rule[],
     });

--- a/src/store/__tests__/storePersistence.test.ts
+++ b/src/store/__tests__/storePersistence.test.ts
@@ -39,6 +39,7 @@ describe('store persistence', () => {
           enabled: true,
           date: '',
           response: null,
+          delayMs: null,
         },
       ],
     };
@@ -68,6 +69,7 @@ describe('store persistence', () => {
         date: '',
         response: null,
         statusCode: 200,
+        delayMs: null,
       })
     );
     expect(setMock).toHaveBeenLastCalledWith({

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -8,4 +8,6 @@ export interface Rule {
   statusCode: number;
   date: string;
   response: string | null;
+  /** Optional delay in milliseconds before responding */
+  delayMs?: number | null;
 }


### PR DESCRIPTION
## Summary
- add new `RuleImportExport` component to handle import/export logic
- integrate `RuleImportExport` into RuleList
- test import/export functionality
- document changeset
- show import/export feedback inline instead of alerts
- append imported rules instead of replacing them
- split `RuleImportExport` into smaller subcomponents

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d0b4a72b88320b502aa30b40b848a