### PR TITLE
Fix bug button visibility on form

### DIFF
--- a/.changeset/hide-bug-button.md
+++ b/.changeset/hide-bug-button.md
@@ -1,0 +1,5 @@
+---
+"http-mocky": patch
+---
+
+Hide bug report button when a rule form is visible.

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -96,4 +96,31 @@ describe('<App />', () => {
       screen.getByRole('button', { name: 'Interception Enabled' })
     ).toBeInTheDocument();
   });
+
+  it('hides the report bug button when a form is visible', () => {
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    );
+
+    // report button visible in list view
+    expect(
+      screen.getByRole('button', { name: /report a bug/i })
+    ).toBeInTheDocument();
+
+    // open add form
+    fireEvent.click(screen.getByRole('button', { name: 'Add Rule' }));
+    expect(
+      screen.queryByRole('button', { name: /report a bug/i })
+    ).not.toBeInTheDocument();
+
+    // return to list and open edit form
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    expect(
+      screen.queryByRole('button', { name: /report a bug/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -44,24 +44,26 @@ const App: React.FC = () => {
           <RuleForm mode="add" onBack={() => setView('list')} />
         )}
       </div>
-      <button
-        type="button"
-        onClick={() =>
-          window.open('https://forms.gle/FNwNhwUvUAiRdzBo9', '_blank')
-        }
-        style={{
-          position: 'fixed',
-          bottom: '20px',
-          right: '20px',
-          padding: '8px 12px',
-          backgroundColor: '#e74c3c',
-          color: '#fff',
-          borderRadius: '4px',
-          boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
-        }}
-      >
-        Report a Bug
-      </button>
+      {view === 'list' && (
+        <button
+          type="button"
+          onClick={() =>
+            window.open('https://forms.gle/FNwNhwUvUAiRdzBo9', '_blank')
+          }
+          style={{
+            position: 'fixed',
+            bottom: '20px',
+            right: '20px',
+            padding: '8px 12px',
+            backgroundColor: '#e74c3c',
+            color: '#fff',
+            borderRadius: '4px',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+          }}
+        >
+          Report a Bug
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide the bug report button while the add/edit form is shown
- test the visibility of the bug report button
- document patch in changeset

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6850cd2418dc8320a3c36a003149f9b6