### PR TITLE
Fix delayMs handling on import/export

### DIFF
--- a/.changeset/vast-wings-itch.md
+++ b/.changeset/vast-wings-itch.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': minor
+---
+
+fix export not including the delay

--- a/src/components/RuleExportButton.tsx
+++ b/src/components/RuleExportButton.tsx
@@ -11,7 +11,11 @@ const RuleExportButton: React.FC<RuleExportButtonProps> = ({
   onMessage,
 }) => {
   const handleExport = () => {
-    const blob = new Blob([JSON.stringify(rules, null, 2)], {
+    const withDelay = rules.map((r) => ({
+      ...r,
+      delayMs: r.delayMs ?? null,
+    }));
+    const blob = new Blob([JSON.stringify(withDelay, null, 2)], {
       type: 'application/json',
     });
     const url = URL.createObjectURL(blob);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,30 +10,18 @@
   "icons": {
     "128": "icon-128.png"
   },
-  "permissions": [
-    "storage"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "contentScript.bundle.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.bundle.js"],
       "run_at": "document_start",
       "world": "ISOLATED"
     },
     {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "window.bundle.js"
-      ],
+      "matches": ["<all_urls>"],
+      "js": ["window.bundle.js"],
       "world": "MAIN",
       "run_at": "document_start"
     }

--- a/src/types/ruleSchema.ts
+++ b/src/types/ruleSchema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+import type { Rule } from './rule';
+
+export const ruleSchema = z.object({
+  id: z.string().optional(),
+  urlPattern: z.string(),
+  isRegExp: z.boolean().optional(),
+  method: z.string(),
+  enabled: z.boolean(),
+  statusCode: z.number(),
+  date: z.string().optional(),
+  response: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((v) => v ?? null),
+  delayMs: z
+    .union([z.number(), z.null(), z.undefined()])
+    .transform((v) => (v === undefined ? null : v)),
+});
+
+export type RuleInput = z.input<typeof ruleSchema>;
+
+export const toRule = (data: RuleInput): Rule => {
+  const parsed = ruleSchema.parse(data);
+  return {
+    id: parsed.id ?? uuidv4(),
+    urlPattern: parsed.urlPattern,
+    isRegExp: parsed.isRegExp ?? false,
+    method: parsed.method,
+    enabled: parsed.enabled,
+    statusCode: parsed.statusCode,
+    date: parsed.date ?? new Date().toISOString().split('T')[0],
+    response: parsed.response,
+    delayMs: parsed.delayMs ?? null,
+  };
+};


### PR DESCRIPTION
## Summary
- add ruleSchema and toRule helper for importing rules
- always export delayMs value
- parse imported rules with toRule

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850e79914608320a20a53de01db64da