### PR TITLE
fix(store): clear matches on rule deletion

### DIFF
--- a/.changeset/clear-matches-on-rule-deletion.md
+++ b/.changeset/clear-matches-on-rule-deletion.md
@@ -1,0 +1,4 @@
+---
+"http-mocky": patch
+---
+Remove stale match entries when a rule is deleted.

--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -3,6 +3,7 @@ import type { Rule } from '../types/rule';
 import { RuleColumn } from './columnConfig';
 import { useAppDispatch, useAppSelector } from '../store';
 import { removeRule, updateRule } from '../Panel/ruleset/rulesetSlice';
+import { removeMatch } from '../store/matchSlice';
 import ToggleButton from './ToggleButton';
 
 interface RuleRowProps {
@@ -14,7 +15,10 @@ interface RuleRowProps {
 const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
   const dispatch = useAppDispatch();
   const matchCount = useAppSelector((state) => state.matches[rule.id] || 0);
-  const handleDelete = () => dispatch(removeRule(rule.id));
+  const handleDelete = () => {
+    dispatch(removeRule(rule.id));
+    dispatch(removeMatch(rule.id));
+  };
   const handleEdit = () => onEdit(rule.id);
 
   const renderCell = (column: RuleColumn): React.ReactNode => {

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -64,13 +64,14 @@ describe('<RuleRow />', () => {
     expect(deleteButton).toBeInTheDocument();
   });
 
-  it('dispatches removeRule when delete button clicked', () => {
+  it('removes rule and its matches when delete button clicked', () => {
     const store = renderRow();
 
     const deleteButton = screen.getByRole('button', { name: 'Delete' });
     fireEvent.click(deleteButton);
 
     expect(store.getState().ruleset).toHaveLength(0);
+    expect(store.getState().matches['1']).toBeUndefined();
   });
 
   it('calls onEdit when edit button clicked', () => {

--- a/src/store/__tests__/matchSlice.test.ts
+++ b/src/store/__tests__/matchSlice.test.ts
@@ -1,6 +1,7 @@
 import reducer, {
   incrementMatch,
   resetMatches,
+  removeMatch,
   MatchCountState,
 } from '../matchSlice';
 
@@ -15,5 +16,11 @@ describe('matchSlice', () => {
     const state: MatchCountState = { abc: 2 };
     const newState = reducer(state, resetMatches());
     expect(newState).toEqual({});
+  });
+
+  it('removes a specific match count', () => {
+    const state: MatchCountState = { abc: 2, def: 1 };
+    const newState = reducer(state, removeMatch('abc'));
+    expect(newState).toEqual({ def: 1 });
   });
 });

--- a/src/store/matchSlice.ts
+++ b/src/store/matchSlice.ts
@@ -15,8 +15,11 @@ const matchSlice = createSlice({
     resetMatches() {
       return {} as MatchCountState;
     },
+    removeMatch(state, action: PayloadAction<string>) {
+      delete state[action.payload];
+    },
   },
 });
 
-export const { incrementMatch, resetMatches } = matchSlice.actions;
+export const { incrementMatch, resetMatches, removeMatch } = matchSlice.actions;
 export default matchSlice.reducer;


### PR DESCRIPTION
## Summary
- remove stale matches when a rule is deleted
- provide removeMatch reducer in match slice
- update RuleRow delete handler
- test for new behaviour

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850e8086d288320ae82d15b8c9725f8