### PR TITLE
Add extension version to panel

### DIFF
--- a/.changeset/dirty-readers-feel.md
+++ b/.changeset/dirty-readers-feel.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat: show extension version in DevTools panel header and document title

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom'; // Import jest-dom for extended matchers
+
+// Provide a minimal chrome.runtime.getManifest mock for tests
+if (!(globalThis as any).chrome) {
+  (globalThis as any).chrome = {
+    runtime: {
+      getManifest: () => ({ version: '0.0.0' }),
+    },
+  } as any;
+}

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setPatched } from '../../store/settingsSlice';
 import InterceptToggleButton from '../../components/InterceptToggleButton';
@@ -14,9 +14,21 @@ const App: React.FC = () => {
   const dispatch = useAppDispatch();
   const patched = useAppSelector((state) => state.settings.patched);
   const monkeyStatus = patched ? '🐵' : '🙈';
+  const [version, setVersion] = useState('');
+
+  useEffect(() => {
+    const manifest = chrome.runtime.getManifest();
+    if (manifest?.version) {
+      setVersion(manifest.version);
+      document.title = `HTTPMocky ${monkeyStatus} (v${manifest.version})`;
+    }
+  }, [monkeyStatus]);
   return (
     <div className="min-h-screen space-y-4 bg-zinc-800 p-4 text-white">
-      <h1 className="text-2xl font-bold">HTTPMocky {monkeyStatus}</h1>
+      <h1 className="text-2xl font-bold">
+        HTTPMocky {monkeyStatus}
+        {version && ` (v${version})`}
+      </h1>
       <InterceptToggleButton
         isEnabled={patched}
         onToggle={() => dispatch(setPatched(!patched))}


### PR DESCRIPTION
## Summary
- display extension version in DevTools panel
- mock `chrome.runtime.getManifest` for tests
- add a changeset entry

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850ed88bd088320884cd7b1296a6ada