### PR TITLE
Add feature flag slice

### DIFF
--- a/.changeset/fifty-melons-invent.md
+++ b/.changeset/fifty-melons-invent.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': minor
+---
+
+add feature settings and hide import/export

--- a/src/components/RuleList.tsx
+++ b/src/components/RuleList.tsx
@@ -13,6 +13,7 @@ const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
   const [filter, setFilter] = useState('');
   const rules = useAppSelector((state) => state.ruleset);
   const rulesCount = rules.length;
+  const { enableImportExport } = useAppSelector((state) => state.features);
 
   return (
     <div className="space-y-4">
@@ -27,7 +28,7 @@ const RuleList: React.FC<RuleListProps> = ({ onEdit, onAdd }) => {
         >
           Add Rule
         </button>
-        <RuleImportExport rules={rules} />
+        {enableImportExport && <RuleImportExport rules={rules} />}
       </div>
       <RuleTable filter={filter} onEdit={onEdit} />
     </div>

--- a/src/components/__tests__/App.test.tsx
+++ b/src/components/__tests__/App.test.tsx
@@ -6,6 +6,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import rulesetReducer from '../../Panel/ruleset/rulesetSlice';
 import settingsReducer from '../../store/settingsSlice';
 import matchesReducer from '../../store/matchSlice';
+import featuresReducer from '../../store/featureSlice';
 import type { Rule } from '../../types/rule';
 import mockData from '../../__mocks__/rules.json';
 
@@ -23,11 +24,13 @@ const createStore = (rules: Rule[] = mockData) =>
       settings: settingsReducer,
       ruleset: rulesetReducer,
       matches: matchesReducer,
+      features: featuresReducer,
     },
     preloadedState: {
       settings: { patched: false },
       ruleset: rules,
       matches: {},
+      features: { enableImportExport: false },
     },
   });
 

--- a/src/pages/Panel/App.tsx
+++ b/src/pages/Panel/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setPatched } from '../../store/settingsSlice';
+import { setFeatures } from '../../store/featureSlice';
 import InterceptToggleButton from '../../components/InterceptToggleButton';
 
 import RuleList from '../../components/RuleList';
@@ -15,6 +16,10 @@ const App: React.FC = () => {
   const patched = useAppSelector((state) => state.settings.patched);
   const monkeyStatus = patched ? '🐵' : '🙈';
   const [version, setVersion] = useState('');
+
+  useEffect(() => {
+    dispatch(setFeatures({ enableImportExport: false }));
+  }, [dispatch]);
 
   useEffect(() => {
     const manifest = chrome.runtime.getManifest();

--- a/src/store/featureSlice.ts
+++ b/src/store/featureSlice.ts
@@ -1,0 +1,16 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { FeatureFlags } from '../types/features';
+import { defaultFeatureFlags } from '../types/features';
+
+const featureSlice = createSlice({
+  name: 'features',
+  initialState: defaultFeatureFlags,
+  reducers: {
+    setFeatures(state, action: PayloadAction<Partial<FeatureFlags>>) {
+      return { ...state, ...action.payload };
+    },
+  },
+});
+
+export const { setFeatures } = featureSlice.actions;
+export default featureSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import settingsReducer, { setPatched } from './settingsSlice';
 import rulesetReducer, { setRules } from '../Panel/ruleset/rulesetSlice';
 import matchesReducer, { incrementMatch } from './matchSlice';
+import featuresReducer from './featureSlice';
 import {
   ExtensionMessageType,
   ExtensionMessageOrigin,
@@ -19,6 +20,7 @@ export const store = configureStore({
     settings: settingsReducer,
     ruleset: rulesetReducer,
     matches: matchesReducer,
+    features: featuresReducer,
   },
 });
 

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,0 +1,7 @@
+export interface FeatureFlags {
+  enableImportExport: boolean;
+}
+
+export const defaultFeatureFlags: FeatureFlags = {
+  enableImportExport: false,
+};


### PR DESCRIPTION
## Summary
- add `FeatureFlags` interface with default flags
- introduce `featureSlice` to manage feature flags
- hydrate `enableImportExport` flag in panel App
- hide `RuleImportExport` controls when feature is disabled
- update App test store setup

## Testing
- `npx eslint . --ext .ts,.tsx`
- `npm test --silent`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6850f302ed6c83208ddf5087bff4623f