### PR TITLE
Implement override tags in rule list

### DIFF
--- a/.changeset/override-tags.md
+++ b/.changeset/override-tags.md
@@ -1,0 +1,5 @@
+---
+'http-mocky': minor
+---
+
+Add override indicator tags to the rule list table.

--- a/src/components/RuleRow.tsx
+++ b/src/components/RuleRow.tsx
@@ -31,6 +31,33 @@ const RuleRow: React.FC<RuleRowProps> = ({ rule, columns, onEdit }) => {
         );
       case RuleColumn.Method:
         return rule.method || 'Match All';
+      case RuleColumn.Overrides: {
+        const tags: string[] = [];
+        if (rule.requestBody != null) tags.push('REQ');
+        if (rule.response != null) tags.push('RES');
+        if (rule.requestHeaders && Object.keys(rule.requestHeaders).length > 0)
+          tags.push('REQ-H');
+        if (
+          rule.responseHeaders &&
+          Object.keys(rule.responseHeaders).length > 0
+        )
+          tags.push('RES-H');
+        if (tags.length === 0) {
+          return <span className="text-gray-400">&ndash;</span>;
+        }
+        return (
+          <div className="flex gap-1">
+            {tags.map((t) => (
+              <span
+                key={t}
+                className="text-xs bg-gray-200 text-gray-800 px-2 py-0.5 rounded-full font-mono"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        );
+      }
       case RuleColumn.Enabled:
         return (
           <ToggleButton

--- a/src/components/__tests__/RuleRow.test.tsx
+++ b/src/components/__tests__/RuleRow.test.tsx
@@ -90,4 +90,19 @@ describe('<RuleRow />', () => {
     const row = screen.getByRole('row');
     expect(row).toHaveTextContent('Match All');
   });
+
+  it('displays override tags when set', () => {
+    const overrideRule: Rule = {
+      ...rule,
+      requestBody: 'x',
+      response: 'y',
+      requestHeaders: { Foo: 'bar' },
+      responseHeaders: { Baz: 'qux' },
+    };
+    renderRow([overrideRule]);
+    expect(screen.getByText('REQ')).toBeInTheDocument();
+    expect(screen.getByText('RES')).toBeInTheDocument();
+    expect(screen.getByText('REQ-H')).toBeInTheDocument();
+    expect(screen.getByText('RES-H')).toBeInTheDocument();
+  });
 });

--- a/src/components/columnConfig.ts
+++ b/src/components/columnConfig.ts
@@ -2,6 +2,7 @@ export enum RuleColumn {
   Enabled = 'enabled',
   UrlPattern = 'urlPattern',
   Method = 'method',
+  Overrides = 'overrides',
   Matches = 'matches',
   Actions = 'actions',
 }
@@ -10,6 +11,7 @@ export const COLUMN_ORDER: RuleColumn[] = [
   RuleColumn.Enabled,
   RuleColumn.UrlPattern,
   RuleColumn.Method,
+  RuleColumn.Overrides,
   RuleColumn.Matches,
   RuleColumn.Actions,
 ];
@@ -18,6 +20,7 @@ export const COLUMN_LABELS: Record<RuleColumn, string> = {
   [RuleColumn.Enabled]: 'Status',
   [RuleColumn.UrlPattern]: 'URL Pattern',
   [RuleColumn.Method]: 'Method',
+  [RuleColumn.Overrides]: 'Overrides',
   [RuleColumn.Matches]: 'Matches',
   [RuleColumn.Actions]: 'Actions',
 };

--- a/src/types/rule.ts
+++ b/src/types/rule.ts
@@ -6,10 +6,14 @@ export interface Rule {
   method: string;
   /** Optional override for the outgoing request body */
   requestBody?: string | null;
+  /** Optional override for outgoing request headers */
+  requestHeaders?: Record<string, string> | null;
   enabled: boolean;
   statusCode: number;
   date: string;
   response: string | null;
+  /** Optional override for incoming response headers */
+  responseHeaders?: Record<string, string> | null;
   /** Optional delay in milliseconds before responding */
   delayMs?: number | null;
 }


### PR DESCRIPTION
## Summary
- add new `Overrides` column config
- render override tags in rule rows
- support additional optional fields on `Rule`
- update tests for override tags
- document change with a changeset

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854944c7a1c8320abe138a21e0af66a