### PR TITLE
fix: clear requestBody for GET

### DIFF
--- a/.changeset/clear-get-body.md
+++ b/.changeset/clear-get-body.md
@@ -1,5 +1,5 @@
 ---
-'request-interceptor': patch
+'http-mocky': patch
 ---
 
 Clear request body when saving rules with methods that don't support a body.

--- a/.changeset/clear-get-body.md
+++ b/.changeset/clear-get-body.md
@@ -1,0 +1,5 @@
+---
+'request-interceptor': patch
+---
+
+Clear request body when saving rules with methods that don't support a body.

--- a/src/components/RuleForm.tsx
+++ b/src/components/RuleForm.tsx
@@ -176,7 +176,10 @@ const RuleForm: React.FC<RuleFormProps> = ({ mode, ruleId, onBack }) => {
       delayMs: delayMs ?? undefined,
     });
 
-    const sanitizedRequestBody = requestBody.trim() === '' ? null : requestBody;
+    let sanitizedRequestBody = requestBody.trim() === '' ? null : requestBody;
+    if (['GET', 'HEAD'].includes(method)) {
+      sanitizedRequestBody = '';
+    }
 
     if (!result.success) {
       const fieldErrs: typeof errors = {};

--- a/src/components/__tests__/RuleForm.test.tsx
+++ b/src/components/__tests__/RuleForm.test.tsx
@@ -123,4 +123,28 @@ describe('<RuleForm />', () => {
     ).toBe('');
     expect(screen.getByLabelText(/override request body/i)).toBeDisabled();
   });
+
+  it('saves empty request body for GET method', () => {
+    const rule: Rule = {
+      id: 'r2',
+      urlPattern: '/foo',
+      method: 'POST',
+      enabled: true,
+      statusCode: 200,
+      date: '',
+      response: '',
+      requestBody: 'data',
+      delayMs: null,
+    } as Rule;
+
+    const { store } = renderForm('edit', [rule]);
+
+    fireEvent.change(screen.getAllByLabelText(/method/i)[0], {
+      target: { value: 'GET' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(store.getState().ruleset[0].requestBody).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- clear the request body before saving GET or HEAD rules
- test saving empty body for GET
- add a patch changeset

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68549dd133288320817863f1332ca1fd